### PR TITLE
Update hashbangs to point to `env python2`

### DIFF
--- a/fslint-gui
+++ b/fslint-gui
@@ -1,5 +1,6 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # vim:fileencoding=utf-8
+
 # Note both python and vim understand the above encoding declaration
 
 # Note using env above will cause the system to register

--- a/fslint/fstool/dupwaste
+++ b/fslint/fstool/dupwaste
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # This script shows the total space wasted by duplicate files
 # as reported by findup (pipe `findup --summary`to this).

--- a/fslint/supprt/md5sum_approx
+++ b/fslint/supprt/md5sum_approx
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 
 # md5sum CHUNK_SIZE bytes of file
 

--- a/fslint/supprt/rmlint/fixdup
+++ b/fslint/supprt/rmlint/fixdup
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
+
 # This is called by findup automatically don't call explicitly
 # unless you really know what you're doing.
 #

--- a/fslint/supprt/rmlint/merge_hardlinks
+++ b/fslint/supprt/rmlint/merge_hardlinks
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # This is a support script for the findup utility which:
 


### PR DESCRIPTION
Default Python is 3 on most distros now.