### PR TITLE
The desktop file needs keywords.

### DIFF
--- a/fslint.desktop
+++ b/fslint.desktop
@@ -7,3 +7,4 @@ Type=Application
 Icon=fslint_icon
 Categories=System;Filesystem;GTK;Utility;
 X-Ubuntu-Gettext-Domain=fslint
+Keywords=duplicate;redundant;file;


### PR DESCRIPTION
When searching for an application (for instance in the GNOME overview), it will search through the application name, the comment (description), the Exec (command line) and through Keywords.

This allows to add relevant words which should also trigger fslint as a relevant answer (especially when you don't remember the software name). Typically, when I use fslint, this is to find "duplicates" or "redundant" "files". These are all important words I would use to look up this software. Otherwise even installed, it is mostly hidden.

Other keywords can be added later to this list if you can think of them. :-)