### PR TITLE
Clarifies directions for "Extra find parameters"

### DIFF
--- a/doc/FAQ
+++ b/doc/FAQ
@@ -49,8 +49,10 @@ A. In "Advanced Search Parameters"->"Paths to exclude", add
    "*/CVS" to exclude all CVS dirs for example
 
 Q. In the GUI how do I exclude files matching a pattern?
-A. In "Advanced Search Parameters"->"Extra find parameters", add
-   "\( ! -name COPYING* -a ! -name LICENSE \)" to exclude licence files for e.g.
+A. In "Advanced Search Parameters"->"Extra find parameters", add:
+     \( ! -name COPYING* -a ! -name LICENSE \)
+   to exclude licence files, for example. See `man find` (section 'EXPRESSION')
+   for more guidance on the proper format for queries.
 
 Q. From the command line how do I exclude paths matching a pattern?
 A. To exclude directories: findup \( -path "*/.svn" \) -prune -o


### PR DESCRIPTION
Howdy, I got tripped up by this FAQ when trying to exclude files in the GUI; I entered the query as printed with quotation marks and got `find: paths must precede expression` in return. I propose this change to avoid other users having the same problem.

No longer ambiguous whether quotes should be entered in this field, which will cause confusing unhelpful error message from `find`.