### PR TITLE
Adding multiple folders to be searched for duplicates

### DIFF
--- a/fslint-gui
+++ b/fslint-gui
@@ -42,6 +42,10 @@ time_commands=False #print sub commands timing on status line
 def puts(string=""): #print is problematic in python 3
     sys.stdout.write(str(string)+'\n')
 
+BAD_DIRS = ['/lost+found','/dev','/proc','/sys','/tmp',
+            '*/.svn','*/CVS', '*/.git', '*/.hg', '*/.bzr',
+            '*/node_modules']
+
 liblocation=os.path.dirname(os.path.abspath(sys.argv[0]))
 locale_base=liblocation+'/po/locale'
 try:
@@ -615,9 +619,7 @@ class fslint(GladeWrapper):
                 self.addDirs(self.ok_dirs, os.path.abspath(path))
             else:
                 self.ShowErrors(_("Invalid path [") + path + "]")
-        for bad_dir in ['/lost+found','/dev','/proc','/sys','/tmp',
-                        '*/.svn','*/CVS', '*/.git', '*/.hg', '*/.bzr',
-                        '*/node_modules']:
+        for bad_dir in BAD_DIRS:
             self.addDirs(self.bad_dirs, bad_dir)
         self._alloc_mouse_cursors()
         self.mode=0
@@ -1196,31 +1198,34 @@ on your system at present."))
     def on_addOkDir_clicked(self, event):
         self.dlgPath.show()
         if not self.dlgPath.canceled:
-            path = self.dlgPath.GtkWindow.get_filename()
-            path = os.path.normpath(path)
-            self.addDirs(self.ok_dirs, path)
+            paths = self.dlgPath.GtkWindow.get_filenames()
+            for path in paths:
+                path = os.path.normpath(path)
+                self.addDirs(self.ok_dirs, path)
 
     def on_addBadDir_clicked(self, event):
         self.dlgPath.show()
         if not self.dlgPath.canceled:
-            path = self.dlgPath.GtkWindow.get_filename()
-            path = os.path.normpath(path)
-            #Note find -path doesn't match dirs with trailing /
-            #and normpath strips trailing / among other things
-            #XXX: The following is not robust. We really should
-            #split specifying wildcards and paths
-            if not os.path.exists(path): #probably a wildcard?
-                #hacky way to get just user specified component
-                dirs = path.split('/')
-                if len(dirs) > 2:
-                    for i in range(len(dirs)):
-                        path = '/'.join(dirs[:i+1])
-                        if path and not os.path.exists(path):
-                            path = '/'.join(dirs[i:])
-                            break
-                if '/' not in path:
-                    path = "*/" + path #more accurate
-            self.addDirs(self.bad_dirs, path)
+            paths = self.dlgPath.GtkWindow.get_filenames()
+            for path in paths:
+                path = self.dlgPath.GtkWindow.get_filename()
+                path = os.path.normpath(path)
+                #Note find -path doesn't match dirs with trailing /
+                #and normpath strips trailing / among other things
+                #XXX: The following is not robust. We really should
+                #split specifying wildcards and paths
+                if not os.path.exists(path): #probably a wildcard?
+                    #hacky way to get just user specified component
+                    dirs = path.split('/')
+                    if len(dirs) > 2:
+                        for i in range(len(dirs)):
+                            path = '/'.join(dirs[:i+1])
+                            if path and not os.path.exists(path):
+                                path = '/'.join(dirs[i:])
+                                break
+                    if '/' not in path:
+                        path = "*/" + path #more accurate
+                self.addDirs(self.bad_dirs, path)
 
     def on_removeOkDir_clicked(self, event):
         self.removeDirs(self.ok_dirs)

--- a/fslint.glade
+++ b/fslint.glade
@@ -1,4127 +1,4127 @@
-<?xml version="1.0" standalone="no"?> <!--*- mode: xml -*-->
+<?xml version="1.0" standalone="no"?><!--*- mode: xml -*-->
 <!DOCTYPE glade-interface SYSTEM "http://glade.gnome.org/glade-2.0.dtd">
 
 <glade-interface>
 
-<widget class="GtkWindow" id="fslint">
-  <property name="visible">True</property>
-  <property name="title" translatable="yes">FSlint</property>
-  <property name="type">GTK_WINDOW_TOPLEVEL</property>
-  <property name="window_position">GTK_WIN_POS_NONE</property>
-  <property name="modal">False</property>
-  <property name="default_width">800</property>
-  <property name="default_height">600</property>
-  <property name="resizable">True</property>
-  <property name="destroy_with_parent">False</property>
-  <property name="icon">fslint_icon.png</property>
-  <property name="decorated">True</property>
-  <property name="skip_taskbar_hint">False</property>
-  <property name="skip_pager_hint">False</property>
-  <property name="type_hint">GDK_WINDOW_TYPE_HINT_NORMAL</property>
-  <property name="gravity">GDK_GRAVITY_NORTH_WEST</property>
-  <property name="focus_on_map">True</property>
-  <property name="urgency_hint">False</property>
-  <signal name="destroy" handler="on_fslint_destroy"/>
-  <signal name="key_press_event" handler="on_fslint_keypress" last_modification_time="Mon, 25 Jun 2007 07:48:30 GMT"/>
-
-  <child>
-    <widget class="GtkVBox" id="vbox1">
-      <property name="visible">True</property>
-      <property name="homogeneous">False</property>
-      <property name="spacing">0</property>
-
-      <child>
-	<widget class="GtkMenuBar" id="menubar1">
-	  <property name="pack_direction">GTK_PACK_DIRECTION_LTR</property>
-	  <property name="child_pack_direction">GTK_PACK_DIRECTION_LTR</property>
-
-	  <child>
-	    <widget class="GtkMenuItem" id="file1">
-	      <property name="visible">True</property>
-	      <property name="label">_File</property>
-	      <property name="use_underline">True</property>
-
-	      <child>
-		<widget class="GtkMenu" id="file1_menu">
-
-		  <child>
-		    <widget class="GtkImageMenuItem" id="quit">
-		      <property name="visible">True</property>
-		      <property name="label">gtk-quit</property>
-		      <property name="use_stock">True</property>
-		      <signal name="activate" handler="on_fslint_destroy" last_modification_time="Tue, 19 Dec 2006 07:58:27 GMT"/>
-		    </widget>
-		  </child>
-		</widget>
-	      </child>
-	    </widget>
-	  </child>
-
-	  <child>
-	    <widget class="GtkMenuItem" id="edit_menu">
-	      <property name="visible">True</property>
-	      <property name="label">_Edit</property>
-	      <property name="use_underline">True</property>
-
-	      <child>
-		<widget class="GtkMenu" id="edit_menu_menu">
-
-		  <child>
-		    <widget class="GtkImageMenuItem" id="open">
-		      <property name="visible">True</property>
-		      <property name="label">gtk-open</property>
-		      <property name="use_stock">True</property>
-		      <signal name="activate" handler="on_open_activate" last_modification_time="Fri, 05 Sep 2008 07:01:52 GMT"/>
-		    </widget>
-		  </child>
-
-		  <child>
-		    <widget class="GtkImageMenuItem" id="open_folder">
-		      <property name="visible">True</property>
-		      <property name="label" translatable="yes">Open _Folder</property>
-		      <property name="use_underline">True</property>
-		      <signal name="activate" handler="on_open_folder_activate" last_modification_time="Fri, 05 Jun 2009 07:05:04 GMT"/>
-
-		      <child internal-child="image">
-			<widget class="GtkImage" id="image15">
-			  <property name="visible">True</property>
-			  <property name="stock">gtk-directory</property>
-			  <property name="icon_size">1</property>
-			  <property name="xalign">0.5</property>
-			  <property name="yalign">0.5</property>
-			  <property name="xpad">0</property>
-			  <property name="ypad">0</property>
-			</widget>
-		      </child>
-		    </widget>
-		  </child>
-
-		  <child>
-		    <widget class="GtkImageMenuItem" id="copy">
-		      <property name="visible">True</property>
-		      <property name="label">gtk-copy</property>
-		      <property name="use_stock">True</property>
-		      <signal name="activate" handler="on_copy_activate" last_modification_time="Mon, 25 Jun 2007 06:36:23 GMT"/>
-		    </widget>
-		  </child>
-
-		  <child>
-		    <widget class="GtkMenuItem" id="rename">
-		      <property name="visible">True</property>
-		      <property name="label" translatable="yes">_Rename...</property>
-		      <property name="use_underline">True</property>
-		      <signal name="activate" handler="on_rename_activate" last_modification_time="Fri, 22 Jun 2007 07:35:13 GMT"/>
-		      <accelerator key="F2" modifiers="0" signal="activate"/>
-		    </widget>
-		  </child>
-
-		  <child>
-		    <widget class="GtkMenuItem" id="select_from_same_folder">
-		      <property name="visible">True</property>
-		      <property name="label" translatable="yes">Select all in this directory</property>
-		      <property name="use_underline">True</property>
-		      <signal name="activate" handler="on_select_from_that_folder_activate" last_modification_time="Fri, 09 Dec 2011 14:54:12 GMT"/>
-		    </widget>
-		  </child>
-		</widget>
-	      </child>
-	    </widget>
-	  </child>
-
-	  <child>
-	    <widget class="GtkMenuItem" id="selection_menu">
-	      <property name="visible">True</property>
-	      <property name="label">_Selection</property>
-	      <property name="use_underline">True</property>
-
-	      <child>
-		<widget class="GtkMenu" id="selection_menu_menu">
-
-		  <child>
-		    <widget class="GtkMenuItem" id="select_using_wildcard">
-		      <property name="visible">True</property>
-		      <property name="label" translatable="yes">Select using wildcard</property>
-		      <property name="use_underline">True</property>
-		      <signal name="activate" handler="on_select_using_wildcard_activate" last_modification_time="Tue, 19 Dec 2006 07:52:22 GMT"/>
-		    </widget>
-		  </child>
-
-		  <child>
-		    <widget class="GtkMenuItem" id="unselect_using_wildcard">
-		      <property name="visible">True</property>
-		      <property name="label" translatable="yes">Unselect using wildcard</property>
-		      <property name="use_underline">True</property>
-		      <signal name="activate" handler="on_unselect_using_wildcard_activate" last_modification_time="Tue, 19 Dec 2006 07:52:22 GMT"/>
-		    </widget>
-		  </child>
-
-		  <child>
-		    <widget class="GtkMenuItem" id="groups_menu">
-		      <property name="visible">True</property>
-		      <property name="label" translatable="yes">within groups</property>
-		      <property name="use_underline">True</property>
-
-		      <child>
-			<widget class="GtkMenu" id="groups_menu_menu">
-
-			  <child>
-			    <widget class="GtkMenuItem" id="select_all_but_first2">
-			      <property name="visible">True</property>
-			      <property name="label" translatable="yes">Select all but first</property>
-			      <property name="use_underline">True</property>
-			      <signal name="activate" handler="on_select_all_but_first_in_each_group_activate" last_modification_time="Fri, 22 Dec 2006 08:40:23 GMT"/>
-			    </widget>
-			  </child>
-
-			  <child>
-			    <widget class="GtkMenuItem" id="select_all_but_newest2">
-			      <property name="visible">True</property>
-			      <property name="label" translatable="yes">Select all but newest</property>
-			      <property name="use_underline">True</property>
-			      <signal name="activate" handler="on_select_all_but_newest_in_each_group_activate" last_modification_time="Fri, 22 Dec 2006 08:40:53 GMT"/>
-			    </widget>
-			  </child>
-
-			  <child>
-			    <widget class="GtkMenuItem" id="select_all_but_oldest2">
-			      <property name="visible">True</property>
-			      <property name="label" translatable="yes">Select all but oldest</property>
-			      <property name="use_underline">True</property>
-			      <signal name="activate" handler="on_select_all_but_oldest_in_each_group_activate" last_modification_time="Fri, 22 Dec 2006 08:41:05 GMT"/>
-			    </widget>
-			  </child>
-			</widget>
-		      </child>
-		    </widget>
-		  </child>
-
-		  <child>
-		    <widget class="GtkMenuItem" id="toggle_selection1">
-		      <property name="visible">True</property>
-		      <property name="label" translatable="yes">Toggle selection</property>
-		      <property name="use_underline">True</property>
-		      <signal name="activate" handler="on_toggle_selection_activate" last_modification_time="Tue, 19 Dec 2006 07:52:22 GMT"/>
-		    </widget>
-		  </child>
-
-		  <child>
-		    <widget class="GtkMenuItem" id="unselect_all1">
-		      <property name="visible">True</property>
-		      <property name="label" translatable="yes">Unselect all</property>
-		      <property name="use_underline">True</property>
-		      <signal name="activate" handler="on_unselect_all_activate" last_modification_time="Tue, 19 Dec 2006 07:52:22 GMT"/>
-		    </widget>
-		  </child>
-		</widget>
-	      </child>
-	    </widget>
-	  </child>
-
-	  <child>
-	    <widget class="GtkMenuItem" id="help">
-	      <property name="visible">True</property>
-	      <property name="label">_Help</property>
-	      <property name="use_underline">True</property>
-
-	      <child>
-		<widget class="GtkMenu" id="help_menu">
-
-		  <child>
-		    <widget class="GtkImageMenuItem" id="about1">
-		      <property name="visible">True</property>
-		      <property name="label">gtk-about</property>
-		      <property name="use_stock">True</property>
-		      <signal name="activate" handler="on_about1_activate" last_modification_time="Tue, 19 Dec 2006 07:58:27 GMT"/>
-		    </widget>
-		  </child>
-		</widget>
-	      </child>
-	    </widget>
-	  </child>
-	</widget>
-	<packing>
-	  <property name="padding">0</property>
-	  <property name="expand">False</property>
-	  <property name="fill">False</property>
-	</packing>
-      </child>
-
-      <child>
-	<widget class="GtkHBox" id="hbox3">
-	  <property name="visible">True</property>
-	  <property name="homogeneous">False</property>
-	  <property name="spacing">0</property>
-
-	  <child>
-	    <widget class="GtkNotebook" id="notebook2">
-	      <property name="border_width">3</property>
-	      <property name="visible">True</property>
-	      <property name="can_focus">True</property>
-	      <property name="show_tabs">True</property>
-	      <property name="show_border">True</property>
-	      <property name="tab_pos">GTK_POS_TOP</property>
-	      <property name="scrollable">False</property>
-	      <property name="enable_popup">False</property>
-
-	      <child>
-		<widget class="GtkHBox" id="hbox2">
-		  <property name="visible">True</property>
-		  <property name="homogeneous">False</property>
-		  <property name="spacing">0</property>
-
-		  <child>
-		    <widget class="GtkVButtonBox" id="vbuttonbox2">
-		      <property name="border_width">2</property>
-		      <property name="visible">True</property>
-		      <property name="layout_style">GTK_BUTTONBOX_SPREAD</property>
-		      <property name="spacing">0</property>
-
-		      <child>
-			<widget class="GtkButton" id="addOkDir">
-			  <property name="border_width">2</property>
-			  <property name="visible">True</property>
-			  <property name="can_default">True</property>
-			  <property name="can_focus">True</property>
-			  <property name="relief">GTK_RELIEF_NORMAL</property>
-			  <property name="focus_on_click">True</property>
-			  <signal name="clicked" handler="on_addOkDir_clicked"/>
-
-			  <child>
-			    <widget class="GtkAlignment" id="alignment1">
-			      <property name="visible">True</property>
-			      <property name="xalign">0</property>
-			      <property name="yalign">0.5</property>
-			      <property name="xscale">0</property>
-			      <property name="yscale">0</property>
-			      <property name="top_padding">0</property>
-			      <property name="bottom_padding">0</property>
-			      <property name="left_padding">0</property>
-			      <property name="right_padding">0</property>
-
-			      <child>
-				<widget class="GtkHBox" id="hbox9">
-				  <property name="visible">True</property>
-				  <property name="homogeneous">False</property>
-				  <property name="spacing">2</property>
-
-				  <child>
-				    <widget class="GtkImage" id="image1">
-				      <property name="visible">True</property>
-				      <property name="stock">gtk-add</property>
-				      <property name="icon_size">4</property>
-				      <property name="xalign">0.5</property>
-				      <property name="yalign">0.5</property>
-				      <property name="xpad">0</property>
-				      <property name="ypad">0</property>
-				    </widget>
-				    <packing>
-				      <property name="padding">0</property>
-				      <property name="expand">False</property>
-				      <property name="fill">False</property>
-				    </packing>
-				  </child>
-
-				  <child>
-				    <widget class="GtkLabel" id="label55">
-				      <property name="visible">True</property>
-				      <property name="label" translatable="yes">Add</property>
-				      <property name="use_underline">True</property>
-				      <property name="use_markup">False</property>
-				      <property name="justify">GTK_JUSTIFY_LEFT</property>
-				      <property name="wrap">False</property>
-				      <property name="selectable">False</property>
-				      <property name="xalign">0.5</property>
-				      <property name="yalign">0.5</property>
-				      <property name="xpad">0</property>
-				      <property name="ypad">0</property>
-				      <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-				      <property name="width_chars">-1</property>
-				      <property name="single_line_mode">False</property>
-				      <property name="angle">0</property>
-				    </widget>
-				    <packing>
-				      <property name="padding">0</property>
-				      <property name="expand">False</property>
-				      <property name="fill">False</property>
-				    </packing>
-				  </child>
-				</widget>
-			      </child>
-			    </widget>
-			  </child>
-			</widget>
-		      </child>
-
-		      <child>
-			<widget class="GtkButton" id="removeOkDir">
-			  <property name="border_width">2</property>
-			  <property name="visible">True</property>
-			  <property name="can_default">True</property>
-			  <property name="can_focus">True</property>
-			  <property name="relief">GTK_RELIEF_NORMAL</property>
-			  <property name="focus_on_click">True</property>
-			  <signal name="clicked" handler="on_removeOkDir_clicked"/>
-
-			  <child>
-			    <widget class="GtkAlignment" id="alignment2">
-			      <property name="visible">True</property>
-			      <property name="xalign">0</property>
-			      <property name="yalign">0.5</property>
-			      <property name="xscale">0</property>
-			      <property name="yscale">0</property>
-			      <property name="top_padding">0</property>
-			      <property name="bottom_padding">0</property>
-			      <property name="left_padding">0</property>
-			      <property name="right_padding">0</property>
-
-			      <child>
-				<widget class="GtkHBox" id="hbox10">
-				  <property name="visible">True</property>
-				  <property name="homogeneous">False</property>
-				  <property name="spacing">2</property>
-
-				  <child>
-				    <widget class="GtkImage" id="image2">
-				      <property name="visible">True</property>
-				      <property name="stock">gtk-remove</property>
-				      <property name="icon_size">4</property>
-				      <property name="xalign">0.5</property>
-				      <property name="yalign">0.5</property>
-				      <property name="xpad">0</property>
-				      <property name="ypad">0</property>
-				    </widget>
-				    <packing>
-				      <property name="padding">0</property>
-				      <property name="expand">False</property>
-				      <property name="fill">False</property>
-				    </packing>
-				  </child>
-
-				  <child>
-				    <widget class="GtkLabel" id="label56">
-				      <property name="visible">True</property>
-				      <property name="label" translatable="yes">Remove</property>
-				      <property name="use_underline">True</property>
-				      <property name="use_markup">False</property>
-				      <property name="justify">GTK_JUSTIFY_LEFT</property>
-				      <property name="wrap">False</property>
-				      <property name="selectable">False</property>
-				      <property name="xalign">0.5</property>
-				      <property name="yalign">0.5</property>
-				      <property name="xpad">0</property>
-				      <property name="ypad">0</property>
-				      <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-				      <property name="width_chars">-1</property>
-				      <property name="single_line_mode">False</property>
-				      <property name="angle">0</property>
-				    </widget>
-				    <packing>
-				      <property name="padding">0</property>
-				      <property name="expand">False</property>
-				      <property name="fill">False</property>
-				    </packing>
-				  </child>
-				</widget>
-			      </child>
-			    </widget>
-			  </child>
-			</widget>
-		      </child>
-		    </widget>
-		    <packing>
-		      <property name="padding">0</property>
-		      <property name="expand">False</property>
-		      <property name="fill">False</property>
-		    </packing>
-		  </child>
-
-		  <child>
-		    <widget class="GtkScrolledWindow" id="scrolledwindow3">
-		      <property name="visible">True</property>
-		      <property name="hscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-		      <property name="vscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-		      <property name="shadow_type">GTK_SHADOW_NONE</property>
-		      <property name="window_placement">GTK_CORNER_TOP_LEFT</property>
-
-		      <child>
-			<widget class="GtkCList" id="ok_dirs">
-			  <property name="border_width">1</property>
-			  <property name="visible">True</property>
-			  <property name="tooltip" translatable="yes">Directories to search</property>
-			  <property name="can_focus">True</property>
-			  <property name="n_columns">1</property>
-			  <property name="column_widths">80</property>
-			  <property name="selection_mode">GTK_SELECTION_MULTIPLE</property>
-			  <property name="show_titles">False</property>
-			  <property name="shadow_type">GTK_SHADOW_IN</property>
-
-			  <child>
-			    <placeholder/>
-			  </child>
-			</widget>
-		      </child>
-		    </widget>
-		    <packing>
-		      <property name="padding">0</property>
-		      <property name="expand">True</property>
-		      <property name="fill">True</property>
-		    </packing>
-		  </child>
-
-		  <child>
-		    <widget class="GtkCheckButton" id="recurseDirs">
-		      <property name="visible">True</property>
-		      <property name="can_focus">True</property>
-		      <property name="label" translatable="yes">recurse?</property>
-		      <property name="use_underline">True</property>
-		      <property name="relief">GTK_RELIEF_NORMAL</property>
-		      <property name="focus_on_click">True</property>
-		      <property name="active">True</property>
-		      <property name="inconsistent">False</property>
-		      <property name="draw_indicator">True</property>
-		    </widget>
-		    <packing>
-		      <property name="padding">0</property>
-		      <property name="expand">False</property>
-		      <property name="fill">False</property>
-		    </packing>
-		  </child>
-		</widget>
-		<packing>
-		  <property name="tab_expand">False</property>
-		  <property name="tab_fill">True</property>
-		</packing>
-	      </child>
-
-	      <child>
-		<widget class="GtkLabel" id="label11">
-		  <property name="visible">True</property>
-		  <property name="label" translatable="yes">Search path</property>
-		  <property name="use_underline">False</property>
-		  <property name="use_markup">False</property>
-		  <property name="justify">GTK_JUSTIFY_CENTER</property>
-		  <property name="wrap">False</property>
-		  <property name="selectable">False</property>
-		  <property name="xalign">0.5</property>
-		  <property name="yalign">0.5</property>
-		  <property name="xpad">0</property>
-		  <property name="ypad">0</property>
-		  <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-		  <property name="width_chars">-1</property>
-		  <property name="single_line_mode">False</property>
-		  <property name="angle">0</property>
-		</widget>
-		<packing>
-		  <property name="type">tab</property>
-		</packing>
-	      </child>
-
-	      <child>
-		<widget class="GtkHBox" id="hbox3">
-		  <property name="visible">True</property>
-		  <property name="homogeneous">False</property>
-		  <property name="spacing">0</property>
-
-		  <child>
-		    <widget class="GtkVButtonBox" id="vbuttonbox3">
-		      <property name="border_width">2</property>
-		      <property name="visible">True</property>
-		      <property name="layout_style">GTK_BUTTONBOX_SPREAD</property>
-		      <property name="spacing">0</property>
-
-		      <child>
-			<widget class="GtkButton" id="addBadDir">
-			  <property name="border_width">2</property>
-			  <property name="visible">True</property>
-			  <property name="can_default">True</property>
-			  <property name="can_focus">True</property>
-			  <property name="relief">GTK_RELIEF_NORMAL</property>
-			  <property name="focus_on_click">True</property>
-			  <signal name="clicked" handler="on_addBadDir_clicked"/>
-
-			  <child>
-			    <widget class="GtkAlignment" id="alignment10">
-			      <property name="visible">True</property>
-			      <property name="xalign">0</property>
-			      <property name="yalign">0.5</property>
-			      <property name="xscale">0</property>
-			      <property name="yscale">0</property>
-			      <property name="top_padding">0</property>
-			      <property name="bottom_padding">0</property>
-			      <property name="left_padding">0</property>
-			      <property name="right_padding">0</property>
-
-			      <child>
-				<widget class="GtkHBox" id="hbox18">
-				  <property name="visible">True</property>
-				  <property name="homogeneous">False</property>
-				  <property name="spacing">2</property>
-
-				  <child>
-				    <widget class="GtkImage" id="image10">
-				      <property name="visible">True</property>
-				      <property name="stock">gtk-add</property>
-				      <property name="icon_size">4</property>
-				      <property name="xalign">0.5</property>
-				      <property name="yalign">0.5</property>
-				      <property name="xpad">0</property>
-				      <property name="ypad">0</property>
-				    </widget>
-				    <packing>
-				      <property name="padding">0</property>
-				      <property name="expand">False</property>
-				      <property name="fill">False</property>
-				    </packing>
-				  </child>
-
-				  <child>
-				    <widget class="GtkLabel" id="label64">
-				      <property name="visible">True</property>
-				      <property name="label" translatable="yes">Add</property>
-				      <property name="use_underline">True</property>
-				      <property name="use_markup">False</property>
-				      <property name="justify">GTK_JUSTIFY_LEFT</property>
-				      <property name="wrap">False</property>
-				      <property name="selectable">False</property>
-				      <property name="xalign">0.5</property>
-				      <property name="yalign">0.5</property>
-				      <property name="xpad">0</property>
-				      <property name="ypad">0</property>
-				      <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-				      <property name="width_chars">-1</property>
-				      <property name="single_line_mode">False</property>
-				      <property name="angle">0</property>
-				    </widget>
-				    <packing>
-				      <property name="padding">0</property>
-				      <property name="expand">False</property>
-				      <property name="fill">False</property>
-				    </packing>
-				  </child>
-				</widget>
-			      </child>
-			    </widget>
-			  </child>
-			</widget>
-		      </child>
-
-		      <child>
-			<widget class="GtkButton" id="removeBadDir">
-			  <property name="border_width">2</property>
-			  <property name="visible">True</property>
-			  <property name="can_default">True</property>
-			  <property name="can_focus">True</property>
-			  <property name="relief">GTK_RELIEF_NORMAL</property>
-			  <property name="focus_on_click">True</property>
-			  <signal name="clicked" handler="on_removeBadDir_clicked"/>
-
-			  <child>
-			    <widget class="GtkAlignment" id="alignment11">
-			      <property name="visible">True</property>
-			      <property name="xalign">0</property>
-			      <property name="yalign">0.5</property>
-			      <property name="xscale">0</property>
-			      <property name="yscale">0</property>
-			      <property name="top_padding">0</property>
-			      <property name="bottom_padding">0</property>
-			      <property name="left_padding">0</property>
-			      <property name="right_padding">0</property>
-
-			      <child>
-				<widget class="GtkHBox" id="hbox19">
-				  <property name="visible">True</property>
-				  <property name="homogeneous">False</property>
-				  <property name="spacing">2</property>
-
-				  <child>
-				    <widget class="GtkImage" id="image11">
-				      <property name="visible">True</property>
-				      <property name="stock">gtk-remove</property>
-				      <property name="icon_size">4</property>
-				      <property name="xalign">0.5</property>
-				      <property name="yalign">0.5</property>
-				      <property name="xpad">0</property>
-				      <property name="ypad">0</property>
-				    </widget>
-				    <packing>
-				      <property name="padding">0</property>
-				      <property name="expand">False</property>
-				      <property name="fill">False</property>
-				    </packing>
-				  </child>
-
-				  <child>
-				    <widget class="GtkLabel" id="label65">
-				      <property name="visible">True</property>
-				      <property name="label" translatable="yes">Remove</property>
-				      <property name="use_underline">True</property>
-				      <property name="use_markup">False</property>
-				      <property name="justify">GTK_JUSTIFY_LEFT</property>
-				      <property name="wrap">False</property>
-				      <property name="selectable">False</property>
-				      <property name="xalign">0.5</property>
-				      <property name="yalign">0.5</property>
-				      <property name="xpad">0</property>
-				      <property name="ypad">0</property>
-				      <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-				      <property name="width_chars">-1</property>
-				      <property name="single_line_mode">False</property>
-				      <property name="angle">0</property>
-				    </widget>
-				    <packing>
-				      <property name="padding">0</property>
-				      <property name="expand">False</property>
-				      <property name="fill">False</property>
-				    </packing>
-				  </child>
-				</widget>
-			      </child>
-			    </widget>
-			  </child>
-			</widget>
-		      </child>
-		    </widget>
-		    <packing>
-		      <property name="padding">0</property>
-		      <property name="expand">False</property>
-		      <property name="fill">True</property>
-		    </packing>
-		  </child>
-
-		  <child>
-		    <widget class="GtkScrolledWindow" id="scrolledwindow4">
-		      <property name="visible">True</property>
-		      <property name="hscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-		      <property name="vscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-		      <property name="shadow_type">GTK_SHADOW_NONE</property>
-		      <property name="window_placement">GTK_CORNER_TOP_LEFT</property>
-
-		      <child>
-			<widget class="GtkCList" id="bad_dirs">
-			  <property name="visible">True</property>
-			  <property name="can_focus">True</property>
-			  <property name="n_columns">1</property>
-			  <property name="column_widths">80</property>
-			  <property name="selection_mode">GTK_SELECTION_MULTIPLE</property>
-			  <property name="show_titles">True</property>
-			  <property name="shadow_type">GTK_SHADOW_IN</property>
-
-			  <child>
-			    <widget class="GtkLabel" id="label18">
-			      <property name="label" translatable="yes">Paths to exclude</property>
-			      <property name="use_underline">False</property>
-			      <property name="use_markup">False</property>
-			      <property name="justify">GTK_JUSTIFY_CENTER</property>
-			      <property name="wrap">False</property>
-			      <property name="selectable">False</property>
-			      <property name="xalign">0.5</property>
-			      <property name="yalign">0.5</property>
-			      <property name="xpad">0</property>
-			      <property name="ypad">0</property>
-			      <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-			      <property name="width_chars">-1</property>
-			      <property name="single_line_mode">False</property>
-			      <property name="angle">0</property>
-			    </widget>
-			  </child>
-			</widget>
-		      </child>
-		    </widget>
-		    <packing>
-		      <property name="padding">0</property>
-		      <property name="expand">True</property>
-		      <property name="fill">True</property>
-		    </packing>
-		  </child>
-
-		  <child>
-		    <widget class="GtkVBox" id="vbox3">
-		      <property name="visible">True</property>
-		      <property name="homogeneous">False</property>
-		      <property name="spacing">7</property>
-
-		      <child>
-			<widget class="GtkLabel" id="label19">
-			  <property name="visible">True</property>
-			  <property name="label" translatable="yes">Extra find parameters</property>
-			  <property name="use_underline">False</property>
-			  <property name="use_markup">False</property>
-			  <property name="justify">GTK_JUSTIFY_CENTER</property>
-			  <property name="wrap">False</property>
-			  <property name="selectable">False</property>
-			  <property name="xalign">0.5</property>
-			  <property name="yalign">0.5</property>
-			  <property name="xpad">0</property>
-			  <property name="ypad">0</property>
-			  <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-			  <property name="width_chars">-1</property>
-			  <property name="single_line_mode">False</property>
-			  <property name="angle">0</property>
-			</widget>
-			<packing>
-			  <property name="padding">0</property>
-			  <property name="expand">False</property>
-			  <property name="fill">False</property>
-			</packing>
-		      </child>
-
-		      <child>
-			<widget class="GtkEntry" id="extra_find_params">
-			  <property name="visible">True</property>
-			  <property name="tooltip" translatable="yes">extra find filtering parameters</property>
-			  <property name="can_focus">True</property>
-			  <property name="editable">True</property>
-			  <property name="visibility">True</property>
-			  <property name="max_length">0</property>
-			  <property name="text"></property>
-			  <property name="has_frame">True</property>
-			  <property name="invisible_char">*</property>
-			  <property name="activates_default">False</property>
-			</widget>
-			<packing>
-			  <property name="padding">0</property>
-			  <property name="expand">False</property>
-			  <property name="fill">False</property>
-			</packing>
-		      </child>
-		    </widget>
-		    <packing>
-		      <property name="padding">0</property>
-		      <property name="expand">True</property>
-		      <property name="fill">True</property>
-		    </packing>
-		  </child>
-		</widget>
-		<packing>
-		  <property name="tab_expand">False</property>
-		  <property name="tab_fill">True</property>
-		</packing>
-	      </child>
-
-	      <child>
-		<widget class="GtkLabel" id="label12">
-		  <property name="visible">True</property>
-		  <property name="label" translatable="yes">Advanced search parameters</property>
-		  <property name="use_underline">False</property>
-		  <property name="use_markup">False</property>
-		  <property name="justify">GTK_JUSTIFY_CENTER</property>
-		  <property name="wrap">False</property>
-		  <property name="selectable">False</property>
-		  <property name="xalign">0.5</property>
-		  <property name="yalign">0.5</property>
-		  <property name="xpad">0</property>
-		  <property name="ypad">0</property>
-		  <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-		  <property name="width_chars">-1</property>
-		  <property name="single_line_mode">False</property>
-		  <property name="angle">0</property>
-		</widget>
-		<packing>
-		  <property name="type">tab</property>
-		</packing>
-	      </child>
-	    </widget>
-	    <packing>
-	      <property name="padding">0</property>
-	      <property name="expand">True</property>
-	      <property name="fill">True</property>
-	    </packing>
-	  </child>
-	</widget>
-	<packing>
-	  <property name="padding">0</property>
-	  <property name="expand">False</property>
-	  <property name="fill">True</property>
-	</packing>
-      </child>
-
-      <child>
-	<widget class="GtkVPaned" id="vpanes">
-	  <property name="border_width">3</property>
-	  <property name="visible">True</property>
-	  <property name="position">400</property>
-
-	  <child>
-	    <widget class="GtkVBox" id="vbox2">
-	      <property name="visible">True</property>
-	      <property name="homogeneous">False</property>
-	      <property name="spacing">0</property>
-
-	      <child>
-		<widget class="GtkNotebook" id="fslint_functions">
-		  <property name="visible">True</property>
-		  <property name="can_focus">True</property>
-		  <property name="show_tabs">True</property>
-		  <property name="show_border">True</property>
-		  <property name="tab_pos">GTK_POS_LEFT</property>
-		  <property name="scrollable">True</property>
-		  <property name="enable_popup">False</property>
-		  <signal name="switch_page" handler="on_fslint_functions_switch_page"/>
-
-		  <child>
-		    <widget class="GtkVBox" id="vbox1">
-		      <property name="visible">True</property>
-		      <property name="homogeneous">False</property>
-		      <property name="spacing">0</property>
-
-		      <child>
-			<widget class="GtkHBox" id="hbox31">
-			  <property name="visible">True</property>
-			  <property name="homogeneous">False</property>
-			  <property name="spacing">0</property>
-
-			  <child>
-			    <widget class="GtkLabel" id="label77">
-			      <property name="visible">True</property>
-			      <property name="label" translatable="yes">Minimum file size:</property>
-			      <property name="use_underline">False</property>
-			      <property name="use_markup">False</property>
-			      <property name="justify">GTK_JUSTIFY_LEFT</property>
-			      <property name="wrap">False</property>
-			      <property name="selectable">False</property>
-			      <property name="xalign">0.5</property>
-			      <property name="yalign">0.5</property>
-			      <property name="xpad">0</property>
-			      <property name="ypad">0</property>
-			      <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-			      <property name="width_chars">-1</property>
-			      <property name="single_line_mode">False</property>
-			      <property name="angle">0</property>
-			    </widget>
-			    <packing>
-			      <property name="padding">0</property>
-			      <property name="expand">False</property>
-			      <property name="fill">False</property>
-			    </packing>
-			  </child>
-
-			  <child>
-			    <widget class="GtkEntry" id="min_size">
-			      <property name="visible">True</property>
-			      <property name="tooltip" translatable="yes">Using find -size syntax</property>
-			      <property name="can_focus">True</property>
-			      <property name="editable">True</property>
-			      <property name="visibility">True</property>
-			      <property name="max_length">0</property>
-			      <property name="text">1</property>
-			      <property name="has_frame">True</property>
-			      <property name="invisible_char">●</property>
-			      <property name="activates_default">False</property>
-			    </widget>
-			    <packing>
-			      <property name="padding">0</property>
-			      <property name="expand">True</property>
-			      <property name="fill">True</property>
-			    </packing>
-			  </child>
-			</widget>
-			<packing>
-			  <property name="padding">0</property>
-			  <property name="expand">False</property>
-			  <property name="fill">False</property>
-			</packing>
-		      </child>
-
-		      <child>
-			<widget class="GtkScrolledWindow" id="scrolledwindow1">
-			  <property name="visible">True</property>
-			  <property name="hscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-			  <property name="vscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-			  <property name="shadow_type">GTK_SHADOW_NONE</property>
-			  <property name="window_placement">GTK_CORNER_TOP_LEFT</property>
-
-			  <child>
-			    <widget class="GtkCList" id="clist_dups">
-			      <property name="border_width">1</property>
-			      <property name="visible">True</property>
-			      <property name="can_focus">True</property>
-			      <property name="n_columns">3</property>
-			      <property name="column_widths">80,180,80</property>
-			      <property name="selection_mode">GTK_SELECTION_MULTIPLE</property>
-			      <property name="show_titles">True</property>
-			      <property name="shadow_type">GTK_SHADOW_IN</property>
-			      <signal name="button_press_event" handler="on_selection_menu_button_press_event" last_modification_time="Tue, 12 Dec 2006 18:44:16 GMT"/>
-
-			      <child>
-				<widget class="GtkLabel" id="label15">
-				  <property name="label" translatable="yes">Name</property>
-				  <property name="use_underline">False</property>
-				  <property name="use_markup">False</property>
-				  <property name="justify">GTK_JUSTIFY_CENTER</property>
-				  <property name="wrap">False</property>
-				  <property name="selectable">False</property>
-				  <property name="xalign">7.45058015283e-09</property>
-				  <property name="yalign">0.5</property>
-				  <property name="xpad">0</property>
-				  <property name="ypad">0</property>
-				  <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-				  <property name="width_chars">-1</property>
-				  <property name="single_line_mode">False</property>
-				  <property name="angle">0</property>
-				</widget>
-			      </child>
-
-			      <child>
-				<widget class="GtkLabel" id="label15m">
-				  <property name="label" translatable="yes">Directory</property>
-				  <property name="use_underline">False</property>
-				  <property name="use_markup">False</property>
-				  <property name="justify">GTK_JUSTIFY_CENTER</property>
-				  <property name="wrap">False</property>
-				  <property name="selectable">False</property>
-				  <property name="xalign">7.45058015283e-09</property>
-				  <property name="yalign">0.5</property>
-				  <property name="xpad">0</property>
-				  <property name="ypad">0</property>
-				  <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-				  <property name="width_chars">-1</property>
-				  <property name="single_line_mode">False</property>
-				  <property name="angle">0</property>
-				</widget>
-			      </child>
-
-			      <child>
-				<widget class="GtkLabel" id="label16">
-				  <property name="label" translatable="yes">Date</property>
-				  <property name="use_underline">False</property>
-				  <property name="use_markup">False</property>
-				  <property name="justify">GTK_JUSTIFY_LEFT</property>
-				  <property name="wrap">False</property>
-				  <property name="selectable">False</property>
-				  <property name="xalign">7.45058015283e-09</property>
-				  <property name="yalign">0.5</property>
-				  <property name="xpad">0</property>
-				  <property name="ypad">0</property>
-				  <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-				  <property name="width_chars">-1</property>
-				  <property name="single_line_mode">False</property>
-				  <property name="angle">0</property>
-				</widget>
-			      </child>
-			    </widget>
-			  </child>
-			</widget>
-			<packing>
-			  <property name="padding">0</property>
-			  <property name="expand">True</property>
-			  <property name="fill">True</property>
-			</packing>
-		      </child>
-		    </widget>
-		    <packing>
-		      <property name="tab_expand">False</property>
-		      <property name="tab_fill">True</property>
-		    </packing>
-		  </child>
-
-		  <child>
-		    <widget class="GtkLabel" id="dup">
-		      <property name="visible">True</property>
-		      <property name="label" translatable="yes">Duplicates</property>
-		      <property name="use_underline">False</property>
-		      <property name="use_markup">False</property>
-		      <property name="justify">GTK_JUSTIFY_CENTER</property>
-		      <property name="wrap">False</property>
-		      <property name="selectable">False</property>
-		      <property name="xalign">0.5</property>
-		      <property name="yalign">0.5</property>
-		      <property name="xpad">0</property>
-		      <property name="ypad">0</property>
-		      <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-		      <property name="width_chars">-1</property>
-		      <property name="single_line_mode">False</property>
-		      <property name="angle">0</property>
-		    </widget>
-		    <packing>
-		      <property name="type">tab</property>
-		    </packing>
-		  </child>
-
-		  <child>
-		    <widget class="GtkHBox" id="hbox22">
-		      <property name="visible">True</property>
-		      <property name="homogeneous">False</property>
-		      <property name="spacing">0</property>
-
-		      <child>
-			<widget class="GtkVPaned" id="pkg_panes">
-			  <property name="visible">True</property>
-			  <property name="can_focus">True</property>
-			  <property name="position">250</property>
-
-			  <child>
-			    <widget class="GtkScrolledWindow" id="scrolledwindow13">
-			      <property name="visible">True</property>
-			      <property name="can_focus">True</property>
-			      <property name="hscrollbar_policy">GTK_POLICY_NEVER</property>
-			      <property name="vscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-			      <property name="shadow_type">GTK_SHADOW_NONE</property>
-			      <property name="window_placement">GTK_CORNER_TOP_LEFT</property>
-
-			      <child>
-				<widget class="GtkCList" id="clist_pkgs">
-				  <property name="border_width">1</property>
-				  <property name="visible">True</property>
-				  <property name="can_focus">True</property>
-				  <property name="n_columns">4</property>
-				  <property name="column_widths">80,80,80,80</property>
-				  <property name="selection_mode">GTK_SELECTION_MULTIPLE</property>
-				  <property name="show_titles">True</property>
-				  <property name="shadow_type">GTK_SHADOW_IN</property>
-				  <signal name="button_press_event" handler="on_clist_pkgs_button_press" last_modification_time="Wed, 11 Jan 2006 08:25:01 GMT"/>
-				  <signal name="key_press_event" handler="on_clist_pkgs_key_press" last_modification_time="Wed, 11 Jan 2006 08:54:05 GMT"/>
-				  <signal name="select_row" handler="on_clist_pkgs_selection_changed" last_modification_time="Wed, 11 Jan 2006 08:54:05 GMT"/>
-				  <signal name="click_column" handler="on_clist_pkgs_click_column" last_modification_time="Wed, 18 Jan 2006 08:45:37 GMT"/>
-
-				  <child>
-				    <widget class="GtkLabel" id="label68">
-				      <property name="label" translatable="yes">Name</property>
-				      <property name="use_underline">False</property>
-				      <property name="use_markup">False</property>
-				      <property name="justify">GTK_JUSTIFY_CENTER</property>
-				      <property name="wrap">False</property>
-				      <property name="selectable">False</property>
-				      <property name="xalign">0</property>
-				      <property name="yalign">0.5</property>
-				      <property name="xpad">0</property>
-				      <property name="ypad">0</property>
-				      <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-				      <property name="width_chars">-1</property>
-				      <property name="single_line_mode">False</property>
-				      <property name="angle">0</property>
-				    </widget>
-				  </child>
-
-				  <child>
-				    <widget class="GtkLabel" id="label69">
-				      <property name="label" translatable="yes">Size</property>
-				      <property name="use_underline">False</property>
-				      <property name="use_markup">False</property>
-				      <property name="justify">GTK_JUSTIFY_RIGHT</property>
-				      <property name="wrap">False</property>
-				      <property name="selectable">False</property>
-				      <property name="xalign">7.45058015283e-09</property>
-				      <property name="yalign">0.5</property>
-				      <property name="xpad">0</property>
-				      <property name="ypad">0</property>
-				      <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-				      <property name="width_chars">-1</property>
-				      <property name="single_line_mode">False</property>
-				      <property name="angle">0</property>
-				    </widget>
-				  </child>
-
-				  <child>
-				    <widget class="GtkLabel" id="label70">
-				      <property name="label">Size_for_Sort</property>
-				      <property name="use_underline">False</property>
-				      <property name="use_markup">False</property>
-				      <property name="justify">GTK_JUSTIFY_RIGHT</property>
-				      <property name="wrap">False</property>
-				      <property name="selectable">False</property>
-				      <property name="xalign">7.45058015283e-09</property>
-				      <property name="yalign">0.5</property>
-				      <property name="xpad">0</property>
-				      <property name="ypad">0</property>
-				      <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-				      <property name="width_chars">-1</property>
-				      <property name="single_line_mode">False</property>
-				      <property name="angle">0</property>
-				    </widget>
-				  </child>
-
-				  <child>
-				    <widget class="GtkLabel" id="label71">
-				      <property name="label">Selection_for_Sort</property>
-				      <property name="use_underline">False</property>
-				      <property name="use_markup">False</property>
-				      <property name="justify">GTK_JUSTIFY_RIGHT</property>
-				      <property name="wrap">False</property>
-				      <property name="selectable">False</property>
-				      <property name="xalign">7.45058015283e-09</property>
-				      <property name="yalign">0.5</property>
-				      <property name="xpad">0</property>
-				      <property name="ypad">0</property>
-				      <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-				      <property name="width_chars">-1</property>
-				      <property name="single_line_mode">False</property>
-				      <property name="angle">0</property>
-				    </widget>
-				  </child>
-				</widget>
-			      </child>
-			    </widget>
-			    <packing>
-			      <property name="shrink">True</property>
-			      <property name="resize">False</property>
-			    </packing>
-			  </child>
-
-			  <child>
-			    <widget class="GtkScrolledWindow" id="scrolledwindow15">
-			      <property name="visible">True</property>
-			      <property name="can_focus">True</property>
-			      <property name="hscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-			      <property name="vscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-			      <property name="shadow_type">GTK_SHADOW_IN</property>
-			      <property name="window_placement">GTK_CORNER_TOP_LEFT</property>
-
-			      <child>
-				<widget class="GtkTextView" id="pkg_info">
-				  <property name="visible">True</property>
-				  <property name="can_focus">True</property>
-				  <property name="editable">False</property>
-				  <property name="overwrite">False</property>
-				  <property name="accepts_tab">True</property>
-				  <property name="justification">GTK_JUSTIFY_LEFT</property>
-				  <property name="wrap_mode">GTK_WRAP_WORD</property>
-				  <property name="cursor_visible">True</property>
-				  <property name="pixels_above_lines">0</property>
-				  <property name="pixels_below_lines">0</property>
-				  <property name="pixels_inside_wrap">0</property>
-				  <property name="left_margin">0</property>
-				  <property name="right_margin">0</property>
-				  <property name="indent">0</property>
-				  <property name="text" translatable="yes"></property>
-				</widget>
-			      </child>
-			    </widget>
-			    <packing>
-			      <property name="shrink">True</property>
-			      <property name="resize">True</property>
-			    </packing>
-			  </child>
-			</widget>
-			<packing>
-			  <property name="padding">0</property>
-			  <property name="expand">True</property>
-			  <property name="fill">True</property>
-			</packing>
-		      </child>
-		    </widget>
-		    <packing>
-		      <property name="tab_expand">False</property>
-		      <property name="tab_fill">True</property>
-		    </packing>
-		  </child>
-
-		  <child>
-		    <widget class="GtkLabel" id="lblPackages">
-		      <property name="visible">True</property>
-		      <property name="label" translatable="yes">Installed packages</property>
-		      <property name="use_underline">False</property>
-		      <property name="use_markup">False</property>
-		      <property name="justify">GTK_JUSTIFY_LEFT</property>
-		      <property name="wrap">False</property>
-		      <property name="selectable">False</property>
-		      <property name="xalign">0.5</property>
-		      <property name="yalign">0.5</property>
-		      <property name="xpad">0</property>
-		      <property name="ypad">0</property>
-		      <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-		      <property name="width_chars">-1</property>
-		      <property name="single_line_mode">False</property>
-		      <property name="angle">0</property>
-		    </widget>
-		    <packing>
-		      <property name="type">tab</property>
-		    </packing>
-		  </child>
-
-		  <child>
-		    <widget class="GtkVBox" id="vbox4">
-		      <property name="visible">True</property>
-		      <property name="homogeneous">False</property>
-		      <property name="spacing">0</property>
-
-		      <child>
-			<widget class="GtkHBox" id="hbox4">
-			  <property name="visible">True</property>
-			  <property name="homogeneous">False</property>
-			  <property name="spacing">0</property>
-
-			  <child>
-			    <widget class="GtkHBox" id="hbox5">
-			      <property name="visible">True</property>
-			      <property name="homogeneous">False</property>
-			      <property name="spacing">0</property>
-
-			      <child>
-				<widget class="GtkLabel" id="lbl_findnl_sensitivity">
-				  <property name="visible">True</property>
-				  <property name="label" translatable="yes">Sensitivity=</property>
-				  <property name="use_underline">False</property>
-				  <property name="use_markup">False</property>
-				  <property name="justify">GTK_JUSTIFY_CENTER</property>
-				  <property name="wrap">False</property>
-				  <property name="selectable">False</property>
-				  <property name="xalign">0.5</property>
-				  <property name="yalign">0.5</property>
-				  <property name="xpad">0</property>
-				  <property name="ypad">0</property>
-				  <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-				  <property name="width_chars">-1</property>
-				  <property name="single_line_mode">False</property>
-				  <property name="angle">0</property>
-				</widget>
-				<packing>
-				  <property name="padding">0</property>
-				  <property name="expand">False</property>
-				  <property name="fill">False</property>
-				</packing>
-			      </child>
-
-			      <child>
-				<widget class="GtkHScale" id="hscale_findnl_level">
-				  <property name="visible">True</property>
-				  <property name="can_focus">True</property>
-				  <property name="draw_value">True</property>
-				  <property name="value_pos">GTK_POS_LEFT</property>
-				  <property name="digits">0</property>
-				  <property name="update_policy">GTK_UPDATE_CONTINUOUS</property>
-				  <property name="inverted">False</property>
-				  <property name="adjustment">2 1 5 1 1 1</property>
-				</widget>
-				<packing>
-				  <property name="padding">0</property>
-				  <property name="expand">True</property>
-				  <property name="fill">True</property>
-				</packing>
-			      </child>
-
-			      <child>
-				<widget class="GtkCheckButton" id="chk_findu8">
-				  <property name="visible">True</property>
-				  <property name="can_focus">True</property>
-				  <property name="label" translatable="yes">invalid UTF8 mode?</property>
-				  <property name="use_underline">True</property>
-				  <property name="relief">GTK_RELIEF_NORMAL</property>
-				  <property name="focus_on_click">True</property>
-				  <property name="active">False</property>
-				  <property name="inconsistent">False</property>
-				  <property name="draw_indicator">True</property>
-				  <signal name="toggled" handler="on_chk_findu8_toggled" last_modification_time="Tue, 30 Aug 2005 17:37:33 GMT"/>
-				</widget>
-				<packing>
-				  <property name="padding">0</property>
-				  <property name="expand">False</property>
-				  <property name="fill">False</property>
-				  <property name="pack_type">GTK_PACK_END</property>
-				</packing>
-			      </child>
-			    </widget>
-			    <packing>
-			      <property name="padding">1</property>
-			      <property name="expand">True</property>
-			      <property name="fill">True</property>
-			    </packing>
-			  </child>
-			</widget>
-			<packing>
-			  <property name="padding">2</property>
-			  <property name="expand">False</property>
-			  <property name="fill">False</property>
-			</packing>
-		      </child>
-
-		      <child>
-			<widget class="GtkScrolledWindow" id="scrolledwindow5">
-			  <property name="visible">True</property>
-			  <property name="hscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-			  <property name="vscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-			  <property name="shadow_type">GTK_SHADOW_NONE</property>
-			  <property name="window_placement">GTK_CORNER_TOP_LEFT</property>
-
-			  <child>
-			    <widget class="GtkCList" id="clist_nl">
-			      <property name="border_width">1</property>
-			      <property name="visible">True</property>
-			      <property name="can_focus">True</property>
-			      <property name="n_columns">2</property>
-			      <property name="column_widths">80,80</property>
-			      <property name="selection_mode">GTK_SELECTION_MULTIPLE</property>
-			      <property name="show_titles">True</property>
-			      <property name="shadow_type">GTK_SHADOW_IN</property>
-			      <signal name="button_press_event" handler="on_selection_menu_button_press_event" last_modification_time="Mon, 18 Dec 2006 19:11:43 GMT"/>
-
-			      <child>
-				<widget class="GtkLabel" id="label20">
-				  <property name="label" translatable="yes">Name</property>
-				  <property name="use_underline">False</property>
-				  <property name="use_markup">False</property>
-				  <property name="justify">GTK_JUSTIFY_CENTER</property>
-				  <property name="wrap">False</property>
-				  <property name="selectable">False</property>
-				  <property name="xalign">7.45058015283e-09</property>
-				  <property name="yalign">0.5</property>
-				  <property name="xpad">0</property>
-				  <property name="ypad">0</property>
-				  <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-				  <property name="width_chars">-1</property>
-				  <property name="single_line_mode">False</property>
-				  <property name="angle">0</property>
-				</widget>
-			      </child>
-
-			      <child>
-				<widget class="GtkLabel" id="label21">
-				  <property name="label" translatable="yes">Directory</property>
-				  <property name="use_underline">False</property>
-				  <property name="use_markup">False</property>
-				  <property name="justify">GTK_JUSTIFY_CENTER</property>
-				  <property name="wrap">False</property>
-				  <property name="selectable">False</property>
-				  <property name="xalign">7.45058015283e-09</property>
-				  <property name="yalign">0.5</property>
-				  <property name="xpad">0</property>
-				  <property name="ypad">0</property>
-				  <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-				  <property name="width_chars">-1</property>
-				  <property name="single_line_mode">False</property>
-				  <property name="angle">0</property>
-				</widget>
-			      </child>
-			    </widget>
-			  </child>
-			</widget>
-			<packing>
-			  <property name="padding">0</property>
-			  <property name="expand">True</property>
-			  <property name="fill">True</property>
-			</packing>
-		      </child>
-		    </widget>
-		    <packing>
-		      <property name="tab_expand">False</property>
-		      <property name="tab_fill">True</property>
-		    </packing>
-		  </child>
-
-		  <child>
-		    <widget class="GtkLabel" id="nl">
-		      <property name="visible">True</property>
-		      <property name="label" translatable="yes">Bad names</property>
-		      <property name="use_underline">False</property>
-		      <property name="use_markup">False</property>
-		      <property name="justify">GTK_JUSTIFY_CENTER</property>
-		      <property name="wrap">False</property>
-		      <property name="selectable">False</property>
-		      <property name="xalign">0.5</property>
-		      <property name="yalign">0.5</property>
-		      <property name="xpad">0</property>
-		      <property name="ypad">0</property>
-		      <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-		      <property name="width_chars">-1</property>
-		      <property name="single_line_mode">False</property>
-		      <property name="angle">0</property>
-		    </widget>
-		    <packing>
-		      <property name="type">tab</property>
-		    </packing>
-		  </child>
-
-		  <child>
-		    <widget class="GtkVBox" id="vbox5">
-		      <property name="visible">True</property>
-		      <property name="homogeneous">False</property>
-		      <property name="spacing">0</property>
-
-		      <child>
-			<widget class="GtkHBox" id="hbox_sn">
-			  <property name="visible">True</property>
-			  <property name="homogeneous">False</property>
-			  <property name="spacing">0</property>
-
-			  <child>
-			    <widget class="GtkLabel" id="label28">
-			      <property name="visible">True</property>
-			      <property name="label" translatable="yes">Search (</property>
-			      <property name="use_underline">False</property>
-			      <property name="use_markup">False</property>
-			      <property name="justify">GTK_JUSTIFY_CENTER</property>
-			      <property name="wrap">False</property>
-			      <property name="selectable">False</property>
-			      <property name="xalign">0.5</property>
-			      <property name="yalign">0.5</property>
-			      <property name="xpad">0</property>
-			      <property name="ypad">0</property>
-			      <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-			      <property name="width_chars">-1</property>
-			      <property name="single_line_mode">False</property>
-			      <property name="angle">0</property>
-			    </widget>
-			    <packing>
-			      <property name="padding">0</property>
-			      <property name="expand">False</property>
-			      <property name="fill">False</property>
-			    </packing>
-			  </child>
-
-			  <child>
-			    <widget class="GtkCheckButton" id="chk_sn_path">
-			      <property name="visible">True</property>
-			      <property name="can_focus">True</property>
-			      <property name="label">$PATH</property>
-			      <property name="use_underline">True</property>
-			      <property name="relief">GTK_RELIEF_NORMAL</property>
-			      <property name="focus_on_click">True</property>
-			      <property name="active">True</property>
-			      <property name="inconsistent">False</property>
-			      <property name="draw_indicator">True</property>
-			      <signal name="toggled" handler="on_chk_sn_path_toggled"/>
-			    </widget>
-			    <packing>
-			      <property name="padding">0</property>
-			      <property name="expand">False</property>
-			      <property name="fill">False</property>
-			    </packing>
-			  </child>
-
-			  <child>
-			    <widget class="GtkLabel" id="label27">
-			      <property name="visible">True</property>
-			      <property name="label" translatable="yes">) for</property>
-			      <property name="use_underline">False</property>
-			      <property name="use_markup">False</property>
-			      <property name="justify">GTK_JUSTIFY_CENTER</property>
-			      <property name="wrap">False</property>
-			      <property name="selectable">False</property>
-			      <property name="xalign">0.5</property>
-			      <property name="yalign">0.5</property>
-			      <property name="xpad">0</property>
-			      <property name="ypad">0</property>
-			      <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-			      <property name="width_chars">-1</property>
-			      <property name="single_line_mode">False</property>
-			      <property name="angle">0</property>
-			    </widget>
-			    <packing>
-			      <property name="padding">0</property>
-			      <property name="expand">False</property>
-			      <property name="fill">False</property>
-			    </packing>
-			  </child>
-
-			  <child>
-			    <widget class="GtkVBox" id="vbox6">
-			      <property name="visible">True</property>
-			      <property name="homogeneous">False</property>
-			      <property name="spacing">0</property>
-
-			      <child>
-				<widget class="GtkHBox" id="hbox_sn_path">
-				  <property name="visible">True</property>
-				  <property name="homogeneous">False</property>
-				  <property name="spacing">0</property>
-
-				  <child>
-				    <widget class="GtkOptionMenu" id="opt_sn_path">
-				      <property name="visible">True</property>
-				      <property name="can_focus">True</property>
-				      <property name="history">0</property>
-
-				      <child internal-child="menu">
-					<widget class="GtkMenu" id="convertwidget9">
-					  <property name="visible">True</property>
-
-					  <child>
-					    <widget class="GtkMenuItem" id="convertwidget11">
-					      <property name="visible">True</property>
-					      <property name="label" translatable="yes">Conflicting files</property>
-					      <property name="use_underline">True</property>
-					    </widget>
-					  </child>
-
-					  <child>
-					    <widget class="GtkMenuItem" id="convertwidget10">
-					      <property name="visible">True</property>
-					      <property name="label" translatable="yes">Aliases</property>
-					      <property name="use_underline">True</property>
-					    </widget>
-					  </child>
-					</widget>
-				      </child>
-				    </widget>
-				    <packing>
-				      <property name="padding">0</property>
-				      <property name="expand">False</property>
-				      <property name="fill">False</property>
-				    </packing>
-				  </child>
-				</widget>
-				<packing>
-				  <property name="padding">0</property>
-				  <property name="expand">True</property>
-				  <property name="fill">True</property>
-				</packing>
-			      </child>
-
-			      <child>
-				<widget class="GtkHBox" id="hbox_sn_paths">
-				  <property name="homogeneous">False</property>
-				  <property name="spacing">0</property>
-
-				  <child>
-				    <widget class="GtkOptionMenu" id="opt_sn_paths">
-				      <property name="visible">True</property>
-				      <property name="can_focus">True</property>
-				      <property name="history">0</property>
-
-				      <child internal-child="menu">
-					<widget class="GtkMenu" id="convertwidget12">
-					  <property name="visible">True</property>
-
-					  <child>
-					    <widget class="GtkMenuItem" id="convertwidget16">
-					      <property name="visible">True</property>
-					      <property name="label" translatable="yes">Case conflicts</property>
-					      <property name="use_underline">True</property>
-					    </widget>
-					  </child>
-
-					  <child>
-					    <widget class="GtkMenuItem" id="convertwidget14">
-					      <property name="visible">True</property>
-					      <property name="label" translatable="yes">Same names</property>
-					      <property name="use_underline">True</property>
-					    </widget>
-					  </child>
-
-					  <child>
-					    <widget class="GtkMenuItem" id="convertwidget15">
-					      <property name="visible">True</property>
-					      <property name="label" translatable="yes">Same names(ignore case)</property>
-					      <property name="use_underline">True</property>
-					    </widget>
-					  </child>
-
-					  <child>
-					    <widget class="GtkMenuItem" id="convertwidget13">
-					      <property name="visible">True</property>
-					      <property name="label" translatable="yes">Aliases</property>
-					      <property name="use_underline">True</property>
-					    </widget>
-					  </child>
-					</widget>
-				      </child>
-				    </widget>
-				    <packing>
-				      <property name="padding">0</property>
-				      <property name="expand">False</property>
-				      <property name="fill">False</property>
-				    </packing>
-				  </child>
-				</widget>
-				<packing>
-				  <property name="padding">0</property>
-				  <property name="expand">True</property>
-				  <property name="fill">True</property>
-				</packing>
-			      </child>
-			    </widget>
-			    <packing>
-			      <property name="padding">0</property>
-			      <property name="expand">True</property>
-			      <property name="fill">True</property>
-			    </packing>
-			  </child>
-			</widget>
-			<packing>
-			  <property name="padding">0</property>
-			  <property name="expand">False</property>
-			  <property name="fill">False</property>
-			</packing>
-		      </child>
-
-		      <child>
-			<widget class="GtkScrolledWindow" id="scrolledwindow6">
-			  <property name="visible">True</property>
-			  <property name="hscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-			  <property name="vscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-			  <property name="shadow_type">GTK_SHADOW_NONE</property>
-			  <property name="window_placement">GTK_CORNER_TOP_LEFT</property>
-
-			  <child>
-			    <widget class="GtkCList" id="clist_sn">
-			      <property name="border_width">1</property>
-			      <property name="visible">True</property>
-			      <property name="can_focus">True</property>
-			      <property name="n_columns">3</property>
-			      <property name="column_widths">80,80,80</property>
-			      <property name="selection_mode">GTK_SELECTION_MULTIPLE</property>
-			      <property name="show_titles">True</property>
-			      <property name="shadow_type">GTK_SHADOW_IN</property>
-			      <signal name="button_press_event" handler="on_selection_menu_button_press_event" last_modification_time="Mon, 18 Dec 2006 19:18:32 GMT"/>
-
-			      <child>
-				<widget class="GtkLabel" id="label24">
-				  <property name="label" translatable="yes">Name</property>
-				  <property name="use_underline">False</property>
-				  <property name="use_markup">False</property>
-				  <property name="justify">GTK_JUSTIFY_LEFT</property>
-				  <property name="wrap">False</property>
-				  <property name="selectable">False</property>
-				  <property name="xalign">7.45058015283e-09</property>
-				  <property name="yalign">0.5</property>
-				  <property name="xpad">0</property>
-				  <property name="ypad">0</property>
-				  <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-				  <property name="width_chars">-1</property>
-				  <property name="single_line_mode">False</property>
-				  <property name="angle">0</property>
-				</widget>
-			      </child>
-
-			      <child>
-				<widget class="GtkLabel" id="label25">
-				  <property name="label" translatable="yes">Directory</property>
-				  <property name="use_underline">False</property>
-				  <property name="use_markup">False</property>
-				  <property name="justify">GTK_JUSTIFY_LEFT</property>
-				  <property name="wrap">False</property>
-				  <property name="selectable">False</property>
-				  <property name="xalign">7.45058015283e-09</property>
-				  <property name="yalign">0.5</property>
-				  <property name="xpad">0</property>
-				  <property name="ypad">0</property>
-				  <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-				  <property name="width_chars">-1</property>
-				  <property name="single_line_mode">False</property>
-				  <property name="angle">0</property>
-				</widget>
-			      </child>
-
-			      <child>
-				<widget class="GtkLabel" id="label26">
-				  <property name="label" translatable="yes">Size</property>
-				  <property name="use_underline">False</property>
-				  <property name="use_markup">False</property>
-				  <property name="justify">GTK_JUSTIFY_RIGHT</property>
-				  <property name="wrap">False</property>
-				  <property name="selectable">False</property>
-				  <property name="xalign">7.45058015283e-09</property>
-				  <property name="yalign">0.5</property>
-				  <property name="xpad">0</property>
-				  <property name="ypad">0</property>
-				  <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-				  <property name="width_chars">-1</property>
-				  <property name="single_line_mode">False</property>
-				  <property name="angle">0</property>
-				</widget>
-			      </child>
-			    </widget>
-			  </child>
-			</widget>
-			<packing>
-			  <property name="padding">0</property>
-			  <property name="expand">True</property>
-			  <property name="fill">True</property>
-			</packing>
-		      </child>
-		    </widget>
-		    <packing>
-		      <property name="tab_expand">False</property>
-		      <property name="tab_fill">True</property>
-		    </packing>
-		  </child>
-
-		  <child>
-		    <widget class="GtkLabel" id="sn">
-		      <property name="visible">True</property>
-		      <property name="label" translatable="yes">Name clashes</property>
-		      <property name="use_underline">False</property>
-		      <property name="use_markup">False</property>
-		      <property name="justify">GTK_JUSTIFY_CENTER</property>
-		      <property name="wrap">False</property>
-		      <property name="selectable">False</property>
-		      <property name="xalign">0.5</property>
-		      <property name="yalign">0.5</property>
-		      <property name="xpad">0</property>
-		      <property name="ypad">0</property>
-		      <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-		      <property name="width_chars">-1</property>
-		      <property name="single_line_mode">False</property>
-		      <property name="angle">0</property>
-		    </widget>
-		    <packing>
-		      <property name="type">tab</property>
-		    </packing>
-		  </child>
-
-		  <child>
-		    <widget class="GtkVBox" id="vbox7">
-		      <property name="visible">True</property>
-		      <property name="homogeneous">False</property>
-		      <property name="spacing">0</property>
-
-		      <child>
-			<widget class="GtkHBox" id="hbox6">
-			  <property name="visible">True</property>
-			  <property name="homogeneous">False</property>
-			  <property name="spacing">0</property>
-
-			  <child>
-			    <widget class="GtkCheckButton" id="chk_tf_core">
-			      <property name="visible">True</property>
-			      <property name="tooltip" translatable="yes">More restrictive search for core files</property>
-			      <property name="can_focus">True</property>
-			      <property name="label" translatable="yes">core file mode?</property>
-			      <property name="use_underline">True</property>
-			      <property name="relief">GTK_RELIEF_NORMAL</property>
-			      <property name="focus_on_click">True</property>
-			      <property name="active">False</property>
-			      <property name="inconsistent">False</property>
-			      <property name="draw_indicator">True</property>
-			    </widget>
-			    <packing>
-			      <property name="padding">0</property>
-			      <property name="expand">False</property>
-			      <property name="fill">False</property>
-			    </packing>
-			  </child>
-
-			  <child>
-			    <widget class="GtkHBox" id="hbox7">
-			      <property name="visible">True</property>
-			      <property name="homogeneous">False</property>
-			      <property name="spacing">0</property>
-
-			      <child>
-				<widget class="GtkSpinButton" id="spin_tf_core">
-				  <property name="visible">True</property>
-				  <property name="tooltip" translatable="yes">days</property>
-				  <property name="can_focus">True</property>
-				  <property name="climb_rate">1</property>
-				  <property name="digits">0</property>
-				  <property name="numeric">True</property>
-				  <property name="update_policy">GTK_UPDATE_ALWAYS</property>
-				  <property name="snap_to_ticks">False</property>
-				  <property name="wrap">False</property>
-				  <property name="adjustment">0 0 9999 1 7 0</property>
-				</widget>
-				<packing>
-				  <property name="padding">0</property>
-				  <property name="expand">False</property>
-				  <property name="fill">False</property>
-				</packing>
-			      </child>
-
-			      <child>
-				<widget class="GtkLabel" id="label33">
-				  <property name="visible">True</property>
-				  <property name="label" translatable="yes">minimum age</property>
-				  <property name="use_underline">False</property>
-				  <property name="use_markup">False</property>
-				  <property name="justify">GTK_JUSTIFY_CENTER</property>
-				  <property name="wrap">False</property>
-				  <property name="selectable">False</property>
-				  <property name="xalign">0.5</property>
-				  <property name="yalign">0.5</property>
-				  <property name="xpad">0</property>
-				  <property name="ypad">0</property>
-				  <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-				  <property name="width_chars">-1</property>
-				  <property name="single_line_mode">False</property>
-				  <property name="angle">0</property>
-				</widget>
-				<packing>
-				  <property name="padding">0</property>
-				  <property name="expand">False</property>
-				  <property name="fill">False</property>
-				</packing>
-			      </child>
-			    </widget>
-			    <packing>
-			      <property name="padding">0</property>
-			      <property name="expand">True</property>
-			      <property name="fill">True</property>
-			    </packing>
-			  </child>
-			</widget>
-			<packing>
-			  <property name="padding">0</property>
-			  <property name="expand">False</property>
-			  <property name="fill">False</property>
-			</packing>
-		      </child>
-
-		      <child>
-			<widget class="GtkScrolledWindow" id="scrolledwindow7">
-			  <property name="visible">True</property>
-			  <property name="hscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-			  <property name="vscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-			  <property name="shadow_type">GTK_SHADOW_NONE</property>
-			  <property name="window_placement">GTK_CORNER_TOP_LEFT</property>
-
-			  <child>
-			    <widget class="GtkCList" id="clist_tf">
-			      <property name="border_width">1</property>
-			      <property name="visible">True</property>
-			      <property name="can_focus">True</property>
-			      <property name="n_columns">4</property>
-			      <property name="column_widths">80,80,80,80</property>
-			      <property name="selection_mode">GTK_SELECTION_MULTIPLE</property>
-			      <property name="show_titles">True</property>
-			      <property name="shadow_type">GTK_SHADOW_IN</property>
-			      <signal name="button_press_event" handler="on_selection_menu_button_press_event" last_modification_time="Mon, 18 Dec 2006 19:18:52 GMT"/>
-
-			      <child>
-				<widget class="GtkLabel" id="label29">
-				  <property name="label" translatable="yes">Name</property>
-				  <property name="use_underline">False</property>
-				  <property name="use_markup">False</property>
-				  <property name="justify">GTK_JUSTIFY_CENTER</property>
-				  <property name="wrap">False</property>
-				  <property name="selectable">False</property>
-				  <property name="xalign">7.45058015283e-09</property>
-				  <property name="yalign">0.5</property>
-				  <property name="xpad">0</property>
-				  <property name="ypad">0</property>
-				  <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-				  <property name="width_chars">-1</property>
-				  <property name="single_line_mode">False</property>
-				  <property name="angle">0</property>
-				</widget>
-			      </child>
-
-			      <child>
-				<widget class="GtkLabel" id="label30">
-				  <property name="label" translatable="yes">Directory</property>
-				  <property name="use_underline">False</property>
-				  <property name="use_markup">False</property>
-				  <property name="justify">GTK_JUSTIFY_CENTER</property>
-				  <property name="wrap">False</property>
-				  <property name="selectable">False</property>
-				  <property name="xalign">7.45058015283e-09</property>
-				  <property name="yalign">0.5</property>
-				  <property name="xpad">0</property>
-				  <property name="ypad">0</property>
-				  <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-				  <property name="width_chars">-1</property>
-				  <property name="single_line_mode">False</property>
-				  <property name="angle">0</property>
-				</widget>
-			      </child>
-
-			      <child>
-				<widget class="GtkLabel" id="label31">
-				  <property name="label" translatable="yes">Size</property>
-				  <property name="use_underline">False</property>
-				  <property name="use_markup">False</property>
-				  <property name="justify">GTK_JUSTIFY_CENTER</property>
-				  <property name="wrap">False</property>
-				  <property name="selectable">False</property>
-				  <property name="xalign">7.45058015283e-09</property>
-				  <property name="yalign">0.5</property>
-				  <property name="xpad">0</property>
-				  <property name="ypad">0</property>
-				  <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-				  <property name="width_chars">-1</property>
-				  <property name="single_line_mode">False</property>
-				  <property name="angle">0</property>
-				</widget>
-			      </child>
-
-			      <child>
-				<widget class="GtkLabel" id="label32">
-				  <property name="label" translatable="yes">Date</property>
-				  <property name="use_underline">False</property>
-				  <property name="use_markup">False</property>
-				  <property name="justify">GTK_JUSTIFY_CENTER</property>
-				  <property name="wrap">False</property>
-				  <property name="selectable">False</property>
-				  <property name="xalign">7.45058015283e-09</property>
-				  <property name="yalign">0.5</property>
-				  <property name="xpad">0</property>
-				  <property name="ypad">0</property>
-				  <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-				  <property name="width_chars">-1</property>
-				  <property name="single_line_mode">False</property>
-				  <property name="angle">0</property>
-				</widget>
-			      </child>
-			    </widget>
-			  </child>
-			</widget>
-			<packing>
-			  <property name="padding">0</property>
-			  <property name="expand">True</property>
-			  <property name="fill">True</property>
-			</packing>
-		      </child>
-		    </widget>
-		    <packing>
-		      <property name="tab_expand">False</property>
-		      <property name="tab_fill">True</property>
-		    </packing>
-		  </child>
-
-		  <child>
-		    <widget class="GtkLabel" id="tf">
-		      <property name="visible">True</property>
-		      <property name="label" translatable="yes">Temp files</property>
-		      <property name="use_underline">False</property>
-		      <property name="use_markup">False</property>
-		      <property name="justify">GTK_JUSTIFY_CENTER</property>
-		      <property name="wrap">False</property>
-		      <property name="selectable">False</property>
-		      <property name="xalign">0.5</property>
-		      <property name="yalign">0.5</property>
-		      <property name="xpad">0</property>
-		      <property name="ypad">0</property>
-		      <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-		      <property name="width_chars">-1</property>
-		      <property name="single_line_mode">False</property>
-		      <property name="angle">0</property>
-		    </widget>
-		    <packing>
-		      <property name="type">tab</property>
-		    </packing>
-		  </child>
-
-		  <child>
-		    <widget class="GtkVBox" id="vbox8">
-		      <property name="visible">True</property>
-		      <property name="homogeneous">False</property>
-		      <property name="spacing">0</property>
-
-		      <child>
-			<widget class="GtkHBox" id="hbox8">
-			  <property name="visible">True</property>
-			  <property name="homogeneous">False</property>
-			  <property name="spacing">0</property>
-
-			  <child>
-			    <widget class="GtkRadioButton" id="opt_bl_dangling">
-			      <property name="visible">True</property>
-			      <property name="can_focus">True</property>
-			      <property name="label" translatable="yes">Dangling</property>
-			      <property name="use_underline">True</property>
-			      <property name="relief">GTK_RELIEF_NORMAL</property>
-			      <property name="focus_on_click">True</property>
-			      <property name="active">True</property>
-			      <property name="inconsistent">False</property>
-			      <property name="draw_indicator">True</property>
-			    </widget>
-			    <packing>
-			      <property name="padding">0</property>
-			      <property name="expand">False</property>
-			      <property name="fill">False</property>
-			    </packing>
-			  </child>
-
-			  <child>
-			    <widget class="GtkRadioButton" id="opt_bl_suspect">
-			      <property name="visible">True</property>
-			      <property name="tooltip" translatable="yes">Absolute links to paths within or below the link's directory</property>
-			      <property name="can_focus">True</property>
-			      <property name="label" translatable="yes">Suspect</property>
-			      <property name="use_underline">True</property>
-			      <property name="relief">GTK_RELIEF_NORMAL</property>
-			      <property name="focus_on_click">True</property>
-			      <property name="active">False</property>
-			      <property name="inconsistent">False</property>
-			      <property name="draw_indicator">True</property>
-			      <property name="group">opt_bl_dangling</property>
-			    </widget>
-			    <packing>
-			      <property name="padding">0</property>
-			      <property name="expand">False</property>
-			      <property name="fill">False</property>
-			    </packing>
-			  </child>
-
-			  <child>
-			    <widget class="GtkRadioButton" id="opt_bl_relative">
-			      <property name="visible">True</property>
-			      <property name="can_focus">True</property>
-			      <property name="label" translatable="yes">Relative</property>
-			      <property name="use_underline">True</property>
-			      <property name="relief">GTK_RELIEF_NORMAL</property>
-			      <property name="focus_on_click">True</property>
-			      <property name="active">False</property>
-			      <property name="inconsistent">False</property>
-			      <property name="draw_indicator">True</property>
-			      <property name="group">opt_bl_dangling</property>
-			    </widget>
-			    <packing>
-			      <property name="padding">0</property>
-			      <property name="expand">False</property>
-			      <property name="fill">False</property>
-			    </packing>
-			  </child>
-
-			  <child>
-			    <widget class="GtkRadioButton" id="opt_bl_absolute">
-			      <property name="visible">True</property>
-			      <property name="can_focus">True</property>
-			      <property name="label" translatable="yes">Absolute</property>
-			      <property name="use_underline">True</property>
-			      <property name="relief">GTK_RELIEF_NORMAL</property>
-			      <property name="focus_on_click">True</property>
-			      <property name="active">False</property>
-			      <property name="inconsistent">False</property>
-			      <property name="draw_indicator">True</property>
-			      <property name="group">opt_bl_dangling</property>
-			    </widget>
-			    <packing>
-			      <property name="padding">0</property>
-			      <property name="expand">False</property>
-			      <property name="fill">False</property>
-			    </packing>
-			  </child>
-
-			  <child>
-			    <widget class="GtkRadioButton" id="opt_bl_redundant">
-			      <property name="visible">True</property>
-			      <property name="tooltip" translatable="yes">/././. ///// /../ etc.</property>
-			      <property name="can_focus">True</property>
-			      <property name="label" translatable="yes">Redundant naming</property>
-			      <property name="use_underline">True</property>
-			      <property name="relief">GTK_RELIEF_NORMAL</property>
-			      <property name="focus_on_click">True</property>
-			      <property name="active">False</property>
-			      <property name="inconsistent">False</property>
-			      <property name="draw_indicator">True</property>
-			      <property name="group">opt_bl_dangling</property>
-			    </widget>
-			    <packing>
-			      <property name="padding">0</property>
-			      <property name="expand">False</property>
-			      <property name="fill">False</property>
-			    </packing>
-			  </child>
-			</widget>
-			<packing>
-			  <property name="padding">0</property>
-			  <property name="expand">False</property>
-			  <property name="fill">False</property>
-			</packing>
-		      </child>
-
-		      <child>
-			<widget class="GtkScrolledWindow" id="scrolledwindow8">
-			  <property name="visible">True</property>
-			  <property name="hscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-			  <property name="vscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-			  <property name="shadow_type">GTK_SHADOW_NONE</property>
-			  <property name="window_placement">GTK_CORNER_TOP_LEFT</property>
-
-			  <child>
-			    <widget class="GtkCList" id="clist_bl">
-			      <property name="border_width">1</property>
-			      <property name="visible">True</property>
-			      <property name="can_focus">True</property>
-			      <property name="n_columns">3</property>
-			      <property name="column_widths">80,80,80</property>
-			      <property name="selection_mode">GTK_SELECTION_MULTIPLE</property>
-			      <property name="show_titles">True</property>
-			      <property name="shadow_type">GTK_SHADOW_IN</property>
-			      <signal name="button_press_event" handler="on_selection_menu_button_press_event" last_modification_time="Mon, 18 Dec 2006 19:19:04 GMT"/>
-
-			      <child>
-				<widget class="GtkLabel" id="label34">
-				  <property name="label" translatable="yes">Name</property>
-				  <property name="use_underline">False</property>
-				  <property name="use_markup">False</property>
-				  <property name="justify">GTK_JUSTIFY_CENTER</property>
-				  <property name="wrap">False</property>
-				  <property name="selectable">False</property>
-				  <property name="xalign">7.45058015283e-09</property>
-				  <property name="yalign">0.5</property>
-				  <property name="xpad">0</property>
-				  <property name="ypad">0</property>
-				  <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-				  <property name="width_chars">-1</property>
-				  <property name="single_line_mode">False</property>
-				  <property name="angle">0</property>
-				</widget>
-			      </child>
-
-			      <child>
-				<widget class="GtkLabel" id="label35">
-				  <property name="label" translatable="yes">Directory</property>
-				  <property name="use_underline">False</property>
-				  <property name="use_markup">False</property>
-				  <property name="justify">GTK_JUSTIFY_CENTER</property>
-				  <property name="wrap">False</property>
-				  <property name="selectable">False</property>
-				  <property name="xalign">7.45058015283e-09</property>
-				  <property name="yalign">0.5</property>
-				  <property name="xpad">0</property>
-				  <property name="ypad">0</property>
-				  <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-				  <property name="width_chars">-1</property>
-				  <property name="single_line_mode">False</property>
-				  <property name="angle">0</property>
-				</widget>
-			      </child>
-
-			      <child>
-				<widget class="GtkLabel" id="label36">
-				  <property name="label" translatable="yes">Target</property>
-				  <property name="use_underline">False</property>
-				  <property name="use_markup">False</property>
-				  <property name="justify">GTK_JUSTIFY_CENTER</property>
-				  <property name="wrap">False</property>
-				  <property name="selectable">False</property>
-				  <property name="xalign">7.45058015283e-09</property>
-				  <property name="yalign">0.5</property>
-				  <property name="xpad">0</property>
-				  <property name="ypad">0</property>
-				  <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-				  <property name="width_chars">-1</property>
-				  <property name="single_line_mode">False</property>
-				  <property name="angle">0</property>
-				</widget>
-			      </child>
-			    </widget>
-			  </child>
-			</widget>
-			<packing>
-			  <property name="padding">0</property>
-			  <property name="expand">True</property>
-			  <property name="fill">True</property>
-			</packing>
-		      </child>
-		    </widget>
-		    <packing>
-		      <property name="tab_expand">False</property>
-		      <property name="tab_fill">True</property>
-		    </packing>
-		  </child>
-
-		  <child>
-		    <widget class="GtkLabel" id="bl">
-		      <property name="visible">True</property>
-		      <property name="label" translatable="yes">Bad symlinks</property>
-		      <property name="use_underline">False</property>
-		      <property name="use_markup">False</property>
-		      <property name="justify">GTK_JUSTIFY_CENTER</property>
-		      <property name="wrap">False</property>
-		      <property name="selectable">False</property>
-		      <property name="xalign">0.5</property>
-		      <property name="yalign">0.5</property>
-		      <property name="xpad">0</property>
-		      <property name="ypad">0</property>
-		      <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-		      <property name="width_chars">-1</property>
-		      <property name="single_line_mode">False</property>
-		      <property name="angle">0</property>
-		    </widget>
-		    <packing>
-		      <property name="type">tab</property>
-		    </packing>
-		  </child>
-
-		  <child>
-		    <widget class="GtkVBox" id="vbox2">
-		      <property name="visible">True</property>
-		      <property name="homogeneous">False</property>
-		      <property name="spacing">0</property>
-
-		      <child>
-			<widget class="GtkScrolledWindow" id="scrolledwindow9">
-			  <property name="visible">True</property>
-			  <property name="hscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-			  <property name="vscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-			  <property name="shadow_type">GTK_SHADOW_NONE</property>
-			  <property name="window_placement">GTK_CORNER_TOP_LEFT</property>
-
-			  <child>
-			    <widget class="GtkCList" id="clist_id">
-			      <property name="border_width">1</property>
-			      <property name="visible">True</property>
-			      <property name="can_focus">True</property>
-			      <property name="n_columns">6</property>
-			      <property name="column_widths">80,80,41,47,80,80</property>
-			      <property name="selection_mode">GTK_SELECTION_MULTIPLE</property>
-			      <property name="show_titles">True</property>
-			      <property name="shadow_type">GTK_SHADOW_IN</property>
-			      <signal name="button_press_event" handler="on_selection_menu_button_press_event" last_modification_time="Mon, 18 Dec 2006 19:19:19 GMT"/>
-
-			      <child>
-				<widget class="GtkLabel" id="label37">
-				  <property name="label" translatable="yes">Name</property>
-				  <property name="use_underline">False</property>
-				  <property name="use_markup">False</property>
-				  <property name="justify">GTK_JUSTIFY_CENTER</property>
-				  <property name="wrap">False</property>
-				  <property name="selectable">False</property>
-				  <property name="xalign">1.22935006175e-07</property>
-				  <property name="yalign">0.5</property>
-				  <property name="xpad">0</property>
-				  <property name="ypad">0</property>
-				  <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-				  <property name="width_chars">-1</property>
-				  <property name="single_line_mode">False</property>
-				  <property name="angle">0</property>
-				</widget>
-			      </child>
-
-			      <child>
-				<widget class="GtkLabel" id="label38">
-				  <property name="label" translatable="yes">Directory</property>
-				  <property name="use_underline">False</property>
-				  <property name="use_markup">False</property>
-				  <property name="justify">GTK_JUSTIFY_CENTER</property>
-				  <property name="wrap">False</property>
-				  <property name="selectable">False</property>
-				  <property name="xalign">7.45058015283e-09</property>
-				  <property name="yalign">0.5</property>
-				  <property name="xpad">0</property>
-				  <property name="ypad">0</property>
-				  <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-				  <property name="width_chars">-1</property>
-				  <property name="single_line_mode">False</property>
-				  <property name="angle">0</property>
-				</widget>
-			      </child>
-
-			      <child>
-				<widget class="GtkLabel" id="label39">
-				  <property name="label" translatable="yes">UID</property>
-				  <property name="use_underline">False</property>
-				  <property name="use_markup">False</property>
-				  <property name="justify">GTK_JUSTIFY_CENTER</property>
-				  <property name="wrap">False</property>
-				  <property name="selectable">False</property>
-				  <property name="xalign">7.45058015283e-09</property>
-				  <property name="yalign">0.5</property>
-				  <property name="xpad">0</property>
-				  <property name="ypad">0</property>
-				  <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-				  <property name="width_chars">-1</property>
-				  <property name="single_line_mode">False</property>
-				  <property name="angle">0</property>
-				</widget>
-			      </child>
-
-			      <child>
-				<widget class="GtkLabel" id="label40">
-				  <property name="label" translatable="yes">GID</property>
-				  <property name="use_underline">False</property>
-				  <property name="use_markup">False</property>
-				  <property name="justify">GTK_JUSTIFY_CENTER</property>
-				  <property name="wrap">False</property>
-				  <property name="selectable">False</property>
-				  <property name="xalign">7.45058015283e-09</property>
-				  <property name="yalign">0.5</property>
-				  <property name="xpad">0</property>
-				  <property name="ypad">0</property>
-				  <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-				  <property name="width_chars">-1</property>
-				  <property name="single_line_mode">False</property>
-				  <property name="angle">0</property>
-				</widget>
-			      </child>
-
-			      <child>
-				<widget class="GtkLabel" id="label41">
-				  <property name="label" translatable="yes">Size</property>
-				  <property name="use_underline">False</property>
-				  <property name="use_markup">False</property>
-				  <property name="justify">GTK_JUSTIFY_CENTER</property>
-				  <property name="wrap">False</property>
-				  <property name="selectable">False</property>
-				  <property name="xalign">7.45058015283e-09</property>
-				  <property name="yalign">0.5</property>
-				  <property name="xpad">0</property>
-				  <property name="ypad">0</property>
-				  <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-				  <property name="width_chars">-1</property>
-				  <property name="single_line_mode">False</property>
-				  <property name="angle">0</property>
-				</widget>
-			      </child>
-
-			      <child>
-				<widget class="GtkLabel" id="label42">
-				  <property name="label" translatable="yes">Date</property>
-				  <property name="use_underline">False</property>
-				  <property name="use_markup">False</property>
-				  <property name="justify">GTK_JUSTIFY_CENTER</property>
-				  <property name="wrap">False</property>
-				  <property name="selectable">False</property>
-				  <property name="xalign">7.45058015283e-09</property>
-				  <property name="yalign">0.5</property>
-				  <property name="xpad">0</property>
-				  <property name="ypad">0</property>
-				  <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-				  <property name="width_chars">-1</property>
-				  <property name="single_line_mode">False</property>
-				  <property name="angle">0</property>
-				</widget>
-			      </child>
-			    </widget>
-			  </child>
-			</widget>
-			<packing>
-			  <property name="padding">0</property>
-			  <property name="expand">True</property>
-			  <property name="fill">True</property>
-			</packing>
-		      </child>
-		    </widget>
-		    <packing>
-		      <property name="tab_expand">False</property>
-		      <property name="tab_fill">True</property>
-		    </packing>
-		  </child>
-
-		  <child>
-		    <widget class="GtkLabel" id="id">
-		      <property name="visible">True</property>
-		      <property name="label" translatable="yes">Bad IDs</property>
-		      <property name="use_underline">False</property>
-		      <property name="use_markup">False</property>
-		      <property name="justify">GTK_JUSTIFY_CENTER</property>
-		      <property name="wrap">False</property>
-		      <property name="selectable">False</property>
-		      <property name="xalign">0.5</property>
-		      <property name="yalign">0.5</property>
-		      <property name="xpad">0</property>
-		      <property name="ypad">0</property>
-		      <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-		      <property name="width_chars">-1</property>
-		      <property name="single_line_mode">False</property>
-		      <property name="angle">0</property>
-		    </widget>
-		    <packing>
-		      <property name="type">tab</property>
-		    </packing>
-		  </child>
-
-		  <child>
-		    <widget class="GtkScrolledWindow" id="scrolledwindow10">
-		      <property name="visible">True</property>
-		      <property name="hscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-		      <property name="vscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-		      <property name="shadow_type">GTK_SHADOW_NONE</property>
-		      <property name="window_placement">GTK_CORNER_TOP_LEFT</property>
-
-		      <child>
-			<widget class="GtkCList" id="clist_ed">
-			  <property name="border_width">1</property>
-			  <property name="visible">True</property>
-			  <property name="can_focus">True</property>
-			  <property name="n_columns">3</property>
-			  <property name="column_widths">80,80,80</property>
-			  <property name="selection_mode">GTK_SELECTION_MULTIPLE</property>
-			  <property name="show_titles">True</property>
-			  <property name="shadow_type">GTK_SHADOW_IN</property>
-			  <signal name="button_press_event" handler="on_selection_menu_button_press_event" last_modification_time="Mon, 18 Dec 2006 19:19:32 GMT"/>
-
-			  <child>
-			    <widget class="GtkLabel" id="label43">
-			      <property name="label" translatable="yes">Name</property>
-			      <property name="use_underline">False</property>
-			      <property name="use_markup">False</property>
-			      <property name="justify">GTK_JUSTIFY_CENTER</property>
-			      <property name="wrap">False</property>
-			      <property name="selectable">False</property>
-			      <property name="xalign">7.45058015283e-09</property>
-			      <property name="yalign">0.5</property>
-			      <property name="xpad">0</property>
-			      <property name="ypad">0</property>
-			      <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-			      <property name="width_chars">-1</property>
-			      <property name="single_line_mode">False</property>
-			      <property name="angle">0</property>
-			    </widget>
-			  </child>
-
-			  <child>
-			    <widget class="GtkLabel" id="label53">
-			      <property name="label" translatable="yes">Directory</property>
-			      <property name="use_underline">False</property>
-			      <property name="use_markup">False</property>
-			      <property name="justify">GTK_JUSTIFY_CENTER</property>
-			      <property name="wrap">False</property>
-			      <property name="selectable">False</property>
-			      <property name="xalign">7.45058015283e-09</property>
-			      <property name="yalign">0.5</property>
-			      <property name="xpad">0</property>
-			      <property name="ypad">0</property>
-			      <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-			      <property name="width_chars">-1</property>
-			      <property name="single_line_mode">False</property>
-			      <property name="angle">0</property>
-			    </widget>
-			  </child>
-
-			  <child>
-			    <widget class="GtkLabel" id="label44">
-			      <property name="label" translatable="yes">Date</property>
-			      <property name="use_underline">False</property>
-			      <property name="use_markup">False</property>
-			      <property name="justify">GTK_JUSTIFY_CENTER</property>
-			      <property name="wrap">False</property>
-			      <property name="selectable">False</property>
-			      <property name="xalign">7.45058015283e-09</property>
-			      <property name="yalign">0.5</property>
-			      <property name="xpad">0</property>
-			      <property name="ypad">0</property>
-			      <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-			      <property name="width_chars">-1</property>
-			      <property name="single_line_mode">False</property>
-			      <property name="angle">0</property>
-			    </widget>
-			  </child>
-			</widget>
-		      </child>
-		    </widget>
-		    <packing>
-		      <property name="tab_expand">False</property>
-		      <property name="tab_fill">True</property>
-		    </packing>
-		  </child>
-
-		  <child>
-		    <widget class="GtkLabel" id="ed">
-		      <property name="visible">True</property>
-		      <property name="label" translatable="yes">Empty directories</property>
-		      <property name="use_underline">False</property>
-		      <property name="use_markup">False</property>
-		      <property name="justify">GTK_JUSTIFY_CENTER</property>
-		      <property name="wrap">False</property>
-		      <property name="selectable">False</property>
-		      <property name="xalign">0.5</property>
-		      <property name="yalign">0.5</property>
-		      <property name="xpad">0</property>
-		      <property name="ypad">0</property>
-		      <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-		      <property name="width_chars">-1</property>
-		      <property name="single_line_mode">False</property>
-		      <property name="angle">0</property>
-		    </widget>
-		    <packing>
-		      <property name="type">tab</property>
-		    </packing>
-		  </child>
-
-		  <child>
-		    <widget class="GtkVBox" id="vbox9">
-		      <property name="visible">True</property>
-		      <property name="homogeneous">False</property>
-		      <property name="spacing">0</property>
-
-		      <child>
-			<widget class="GtkCheckButton" id="chk_ns_path">
-			  <property name="visible">True</property>
-			  <property name="can_focus">True</property>
-			  <property name="label" translatable="yes">Search $PATH</property>
-			  <property name="use_underline">True</property>
-			  <property name="relief">GTK_RELIEF_NORMAL</property>
-			  <property name="focus_on_click">True</property>
-			  <property name="active">True</property>
-			  <property name="inconsistent">False</property>
-			  <property name="draw_indicator">True</property>
-			</widget>
-			<packing>
-			  <property name="padding">0</property>
-			  <property name="expand">False</property>
-			  <property name="fill">False</property>
-			</packing>
-		      </child>
-
-		      <child>
-			<widget class="GtkScrolledWindow" id="scrolledwindow11">
-			  <property name="visible">True</property>
-			  <property name="hscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-			  <property name="vscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-			  <property name="shadow_type">GTK_SHADOW_NONE</property>
-			  <property name="window_placement">GTK_CORNER_TOP_LEFT</property>
-
-			  <child>
-			    <widget class="GtkCList" id="clist_ns">
-			      <property name="border_width">1</property>
-			      <property name="visible">True</property>
-			      <property name="can_focus">True</property>
-			      <property name="n_columns">4</property>
-			      <property name="column_widths">80,80,80,80</property>
-			      <property name="selection_mode">GTK_SELECTION_MULTIPLE</property>
-			      <property name="show_titles">True</property>
-			      <property name="shadow_type">GTK_SHADOW_IN</property>
-			      <signal name="button_press_event" handler="on_selection_menu_button_press_event" last_modification_time="Mon, 18 Dec 2006 19:19:47 GMT"/>
-
-			      <child>
-				<widget class="GtkLabel" id="label45">
-				  <property name="label" translatable="yes">Name</property>
-				  <property name="use_underline">False</property>
-				  <property name="use_markup">False</property>
-				  <property name="justify">GTK_JUSTIFY_CENTER</property>
-				  <property name="wrap">False</property>
-				  <property name="selectable">False</property>
-				  <property name="xalign">0</property>
-				  <property name="yalign">0.5</property>
-				  <property name="xpad">0</property>
-				  <property name="ypad">0</property>
-				  <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-				  <property name="width_chars">-1</property>
-				  <property name="single_line_mode">False</property>
-				  <property name="angle">0</property>
-				</widget>
-			      </child>
-
-			      <child>
-				<widget class="GtkLabel" id="label46">
-				  <property name="label" translatable="yes">Directory</property>
-				  <property name="use_underline">False</property>
-				  <property name="use_markup">False</property>
-				  <property name="justify">GTK_JUSTIFY_CENTER</property>
-				  <property name="wrap">False</property>
-				  <property name="selectable">False</property>
-				  <property name="xalign">7.45058015283e-09</property>
-				  <property name="yalign">0.5</property>
-				  <property name="xpad">0</property>
-				  <property name="ypad">0</property>
-				  <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-				  <property name="width_chars">-1</property>
-				  <property name="single_line_mode">False</property>
-				  <property name="angle">0</property>
-				</widget>
-			      </child>
-
-			      <child>
-				<widget class="GtkLabel" id="label47">
-				  <property name="label" translatable="yes">Size</property>
-				  <property name="use_underline">False</property>
-				  <property name="use_markup">False</property>
-				  <property name="justify">GTK_JUSTIFY_CENTER</property>
-				  <property name="wrap">False</property>
-				  <property name="selectable">False</property>
-				  <property name="xalign">7.45058015283e-09</property>
-				  <property name="yalign">0.5</property>
-				  <property name="xpad">0</property>
-				  <property name="ypad">0</property>
-				  <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-				  <property name="width_chars">-1</property>
-				  <property name="single_line_mode">False</property>
-				  <property name="angle">0</property>
-				</widget>
-			      </child>
-
-			      <child>
-				<widget class="GtkLabel" id="label52">
-				  <property name="label" translatable="yes">Date</property>
-				  <property name="use_underline">False</property>
-				  <property name="use_markup">False</property>
-				  <property name="justify">GTK_JUSTIFY_CENTER</property>
-				  <property name="wrap">False</property>
-				  <property name="selectable">False</property>
-				  <property name="xalign">7.45058015283e-09</property>
-				  <property name="yalign">0.5</property>
-				  <property name="xpad">0</property>
-				  <property name="ypad">0</property>
-				  <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-				  <property name="width_chars">-1</property>
-				  <property name="single_line_mode">False</property>
-				  <property name="angle">0</property>
-				</widget>
-			      </child>
-			    </widget>
-			  </child>
-			</widget>
-			<packing>
-			  <property name="padding">0</property>
-			  <property name="expand">True</property>
-			  <property name="fill">True</property>
-			</packing>
-		      </child>
-		    </widget>
-		    <packing>
-		      <property name="tab_expand">False</property>
-		      <property name="tab_fill">True</property>
-		    </packing>
-		  </child>
-
-		  <child>
-		    <widget class="GtkLabel" id="ns">
-		      <property name="visible">True</property>
-		      <property name="label" translatable="yes">Non stripped binaries</property>
-		      <property name="use_underline">False</property>
-		      <property name="use_markup">False</property>
-		      <property name="justify">GTK_JUSTIFY_CENTER</property>
-		      <property name="wrap">False</property>
-		      <property name="selectable">False</property>
-		      <property name="xalign">0.5</property>
-		      <property name="yalign">0.5</property>
-		      <property name="xpad">0</property>
-		      <property name="ypad">0</property>
-		      <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-		      <property name="width_chars">-1</property>
-		      <property name="single_line_mode">False</property>
-		      <property name="angle">0</property>
-		    </widget>
-		    <packing>
-		      <property name="type">tab</property>
-		    </packing>
-		  </child>
-
-		  <child>
-		    <widget class="GtkVBox" id="vbox10">
-		      <property name="visible">True</property>
-		      <property name="homogeneous">False</property>
-		      <property name="spacing">0</property>
-
-		      <child>
-			<widget class="GtkHBox" id="hbox24">
-			  <property name="visible">True</property>
-			  <property name="homogeneous">False</property>
-			  <property name="spacing">2</property>
-
-			  <child>
-			    <widget class="GtkHBox" id="hbox25">
-			      <property name="visible">True</property>
-			      <property name="homogeneous">False</property>
-			      <property name="spacing">0</property>
-
-			      <child>
-				<widget class="GtkCheckButton" id="chkTabs">
-				  <property name="visible">True</property>
-				  <property name="can_focus">True</property>
-				  <property name="relief">GTK_RELIEF_NORMAL</property>
-				  <property name="focus_on_click">True</property>
-				  <property name="active">False</property>
-				  <property name="inconsistent">False</property>
-				  <property name="draw_indicator">True</property>
-
-				  <child>
-				    <widget class="GtkAlignment" id="alignment15">
-				      <property name="visible">True</property>
-				      <property name="xalign">0.5</property>
-				      <property name="yalign">0.5</property>
-				      <property name="xscale">0</property>
-				      <property name="yscale">0</property>
-				      <property name="top_padding">0</property>
-				      <property name="bottom_padding">0</property>
-				      <property name="left_padding">0</property>
-				      <property name="right_padding">0</property>
-
-				      <child>
-					<widget class="GtkHBox" id="hbox27">
-					  <property name="visible">True</property>
-					  <property name="homogeneous">False</property>
-					  <property name="spacing">2</property>
-
-					  <child>
-					    <widget class="GtkImage" id="image14">
-					      <property name="visible">True</property>
-					      <property name="stock">gtk-indent</property>
-					      <property name="icon_size">4</property>
-					      <property name="xalign">0.5</property>
-					      <property name="yalign">0.5</property>
-					      <property name="xpad">0</property>
-					      <property name="ypad">0</property>
-					    </widget>
-					    <packing>
-					      <property name="padding">0</property>
-					      <property name="expand">False</property>
-					      <property name="fill">False</property>
-					    </packing>
-					  </child>
-
-					  <child>
-					    <widget class="GtkLabel" id="label73">
-					      <property name="visible">True</property>
-					      <property name="label" translatable="yes">bad indenting for indent width</property>
-					      <property name="use_underline">True</property>
-					      <property name="use_markup">False</property>
-					      <property name="justify">GTK_JUSTIFY_LEFT</property>
-					      <property name="wrap">False</property>
-					      <property name="selectable">False</property>
-					      <property name="xalign">0.5</property>
-					      <property name="yalign">0.5</property>
-					      <property name="xpad">0</property>
-					      <property name="ypad">0</property>
-					      <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-					      <property name="width_chars">-1</property>
-					      <property name="single_line_mode">False</property>
-					      <property name="angle">0</property>
-					    </widget>
-					    <packing>
-					      <property name="padding">0</property>
-					      <property name="expand">False</property>
-					      <property name="fill">False</property>
-					    </packing>
-					  </child>
-					</widget>
-				      </child>
-				    </widget>
-				  </child>
-				</widget>
-				<packing>
-				  <property name="padding">0</property>
-				  <property name="expand">False</property>
-				  <property name="fill">False</property>
-				</packing>
-			      </child>
-
-			      <child>
-				<widget class="GtkSpinButton" id="spinTabs">
-				  <property name="visible">True</property>
-				  <property name="can_focus">True</property>
-				  <property name="climb_rate">1</property>
-				  <property name="digits">0</property>
-				  <property name="numeric">True</property>
-				  <property name="update_policy">GTK_UPDATE_ALWAYS</property>
-				  <property name="snap_to_ticks">False</property>
-				  <property name="wrap">False</property>
-				  <property name="adjustment">8 2 16 1 4 0</property>
-				</widget>
-				<packing>
-				  <property name="padding">0</property>
-				  <property name="expand">False</property>
-				  <property name="fill">False</property>
-				  <property name="pack_type">GTK_PACK_END</property>
-				</packing>
-			      </child>
-			    </widget>
-			    <packing>
-			      <property name="padding">0</property>
-			      <property name="expand">False</property>
-			      <property name="fill">False</property>
-			    </packing>
-			  </child>
-
-			  <child>
-			    <widget class="GtkCheckButton" id="chkWhitespace">
-			      <property name="visible">True</property>
-			      <property name="can_focus">True</property>
-			      <property name="relief">GTK_RELIEF_NORMAL</property>
-			      <property name="focus_on_click">True</property>
-			      <property name="active">True</property>
-			      <property name="inconsistent">False</property>
-			      <property name="draw_indicator">True</property>
-
-			      <child>
-				<widget class="GtkAlignment" id="alignment14">
-				  <property name="visible">True</property>
-				  <property name="xalign">0.5</property>
-				  <property name="yalign">0.5</property>
-				  <property name="xscale">0</property>
-				  <property name="yscale">0</property>
-				  <property name="top_padding">0</property>
-				  <property name="bottom_padding">0</property>
-				  <property name="left_padding">0</property>
-				  <property name="right_padding">0</property>
-
-				  <child>
-				    <widget class="GtkHBox" id="hbox26">
-				      <property name="visible">True</property>
-				      <property name="homogeneous">False</property>
-				      <property name="spacing">2</property>
-
-				      <child>
-					<widget class="GtkImage" id="image13">
-					  <property name="visible">True</property>
-					  <property name="stock">gtk-unindent</property>
-					  <property name="icon_size">4</property>
-					  <property name="xalign">0.5</property>
-					  <property name="yalign">0.5</property>
-					  <property name="xpad">0</property>
-					  <property name="ypad">0</property>
+	<widget class="GtkWindow" id="fslint">
+		<property name="visible">True</property>
+		<property name="title" translatable="yes">FSlint</property>
+		<property name="type">GTK_WINDOW_TOPLEVEL</property>
+		<property name="window_position">GTK_WIN_POS_NONE</property>
+		<property name="modal">False</property>
+		<property name="default_width">800</property>
+		<property name="default_height">600</property>
+		<property name="resizable">True</property>
+		<property name="destroy_with_parent">False</property>
+		<property name="icon">fslint_icon.png</property>
+		<property name="decorated">True</property>
+		<property name="skip_taskbar_hint">False</property>
+		<property name="skip_pager_hint">False</property>
+		<property name="type_hint">GDK_WINDOW_TYPE_HINT_NORMAL</property>
+		<property name="gravity">GDK_GRAVITY_NORTH_WEST</property>
+		<property name="focus_on_map">True</property>
+		<property name="urgency_hint">False</property>
+		<signal name="destroy" handler="on_fslint_destroy"/>
+		<signal name="key_press_event" handler="on_fslint_keypress" last_modification_time="Mon, 25 Jun 2007 07:48:30 GMT"/>
+
+		<child>
+			<widget class="GtkVBox" id="vbox1">
+				<property name="visible">True</property>
+				<property name="homogeneous">False</property>
+				<property name="spacing">0</property>
+
+				<child>
+					<widget class="GtkMenuBar" id="menubar1">
+						<property name="pack_direction">GTK_PACK_DIRECTION_LTR</property>
+						<property name="child_pack_direction">GTK_PACK_DIRECTION_LTR</property>
+
+						<child>
+							<widget class="GtkMenuItem" id="file1">
+								<property name="visible">True</property>
+								<property name="label">_File</property>
+								<property name="use_underline">True</property>
+
+								<child>
+									<widget class="GtkMenu" id="file1_menu">
+
+										<child>
+											<widget class="GtkImageMenuItem" id="quit">
+												<property name="visible">True</property>
+												<property name="label">gtk-quit</property>
+												<property name="use_stock">True</property>
+												<signal name="activate" handler="on_fslint_destroy" last_modification_time="Tue, 19 Dec 2006 07:58:27 GMT"/>
+											</widget>
+										</child>
+									</widget>
+								</child>
+							</widget>
+						</child>
+
+						<child>
+							<widget class="GtkMenuItem" id="edit_menu">
+								<property name="visible">True</property>
+								<property name="label">_Edit</property>
+								<property name="use_underline">True</property>
+
+								<child>
+									<widget class="GtkMenu" id="edit_menu_menu">
+
+										<child>
+											<widget class="GtkImageMenuItem" id="open">
+												<property name="visible">True</property>
+												<property name="label">gtk-open</property>
+												<property name="use_stock">True</property>
+												<signal name="activate" handler="on_open_activate" last_modification_time="Fri, 05 Sep 2008 07:01:52 GMT"/>
+											</widget>
+										</child>
+
+										<child>
+											<widget class="GtkImageMenuItem" id="open_folder">
+												<property name="visible">True</property>
+												<property name="label" translatable="yes">Open _Folder</property>
+												<property name="use_underline">True</property>
+												<signal name="activate" handler="on_open_folder_activate" last_modification_time="Fri, 05 Jun 2009 07:05:04 GMT"/>
+
+												<child internal-child="image">
+													<widget class="GtkImage" id="image15">
+														<property name="visible">True</property>
+														<property name="stock">gtk-directory</property>
+														<property name="icon_size">1</property>
+														<property name="xalign">0.5</property>
+														<property name="yalign">0.5</property>
+														<property name="xpad">0</property>
+														<property name="ypad">0</property>
+													</widget>
+												</child>
+											</widget>
+										</child>
+
+										<child>
+											<widget class="GtkImageMenuItem" id="copy">
+												<property name="visible">True</property>
+												<property name="label">gtk-copy</property>
+												<property name="use_stock">True</property>
+												<signal name="activate" handler="on_copy_activate" last_modification_time="Mon, 25 Jun 2007 06:36:23 GMT"/>
+											</widget>
+										</child>
+
+										<child>
+											<widget class="GtkMenuItem" id="rename">
+												<property name="visible">True</property>
+												<property name="label" translatable="yes">_Rename...</property>
+												<property name="use_underline">True</property>
+												<signal name="activate" handler="on_rename_activate" last_modification_time="Fri, 22 Jun 2007 07:35:13 GMT"/>
+												<accelerator key="F2" modifiers="0" signal="activate"/>
+											</widget>
+										</child>
+
+										<child>
+											<widget class="GtkMenuItem" id="select_from_same_folder">
+												<property name="visible">True</property>
+												<property name="label" translatable="yes">Select all in this directory</property>
+												<property name="use_underline">True</property>
+												<signal name="activate" handler="on_select_from_that_folder_activate" last_modification_time="Fri, 09 Dec 2011 14:54:12 GMT"/>
+											</widget>
+										</child>
+									</widget>
+								</child>
+							</widget>
+						</child>
+
+						<child>
+							<widget class="GtkMenuItem" id="selection_menu">
+								<property name="visible">True</property>
+								<property name="label">_Selection</property>
+								<property name="use_underline">True</property>
+
+								<child>
+									<widget class="GtkMenu" id="selection_menu_menu">
+
+										<child>
+											<widget class="GtkMenuItem" id="select_using_wildcard">
+												<property name="visible">True</property>
+												<property name="label" translatable="yes">Select using wildcard</property>
+												<property name="use_underline">True</property>
+												<signal name="activate" handler="on_select_using_wildcard_activate" last_modification_time="Tue, 19 Dec 2006 07:52:22 GMT"/>
+											</widget>
+										</child>
+
+										<child>
+											<widget class="GtkMenuItem" id="unselect_using_wildcard">
+												<property name="visible">True</property>
+												<property name="label" translatable="yes">Unselect using wildcard</property>
+												<property name="use_underline">True</property>
+												<signal name="activate" handler="on_unselect_using_wildcard_activate" last_modification_time="Tue, 19 Dec 2006 07:52:22 GMT"/>
+											</widget>
+										</child>
+
+										<child>
+											<widget class="GtkMenuItem" id="groups_menu">
+												<property name="visible">True</property>
+												<property name="label" translatable="yes">within groups</property>
+												<property name="use_underline">True</property>
+
+												<child>
+													<widget class="GtkMenu" id="groups_menu_menu">
+
+														<child>
+															<widget class="GtkMenuItem" id="select_all_but_first2">
+																<property name="visible">True</property>
+																<property name="label" translatable="yes">Select all but first</property>
+																<property name="use_underline">True</property>
+																<signal name="activate" handler="on_select_all_but_first_in_each_group_activate" last_modification_time="Fri, 22 Dec 2006 08:40:23 GMT"/>
+															</widget>
+														</child>
+
+														<child>
+															<widget class="GtkMenuItem" id="select_all_but_newest2">
+																<property name="visible">True</property>
+																<property name="label" translatable="yes">Select all but newest</property>
+																<property name="use_underline">True</property>
+																<signal name="activate" handler="on_select_all_but_newest_in_each_group_activate" last_modification_time="Fri, 22 Dec 2006 08:40:53 GMT"/>
+															</widget>
+														</child>
+
+														<child>
+															<widget class="GtkMenuItem" id="select_all_but_oldest2">
+																<property name="visible">True</property>
+																<property name="label" translatable="yes">Select all but oldest</property>
+																<property name="use_underline">True</property>
+																<signal name="activate" handler="on_select_all_but_oldest_in_each_group_activate" last_modification_time="Fri, 22 Dec 2006 08:41:05 GMT"/>
+															</widget>
+														</child>
+													</widget>
+												</child>
+											</widget>
+										</child>
+
+										<child>
+											<widget class="GtkMenuItem" id="toggle_selection1">
+												<property name="visible">True</property>
+												<property name="label" translatable="yes">Toggle selection</property>
+												<property name="use_underline">True</property>
+												<signal name="activate" handler="on_toggle_selection_activate" last_modification_time="Tue, 19 Dec 2006 07:52:22 GMT"/>
+											</widget>
+										</child>
+
+										<child>
+											<widget class="GtkMenuItem" id="unselect_all1">
+												<property name="visible">True</property>
+												<property name="label" translatable="yes">Unselect all</property>
+												<property name="use_underline">True</property>
+												<signal name="activate" handler="on_unselect_all_activate" last_modification_time="Tue, 19 Dec 2006 07:52:22 GMT"/>
+											</widget>
+										</child>
+									</widget>
+								</child>
+							</widget>
+						</child>
+
+						<child>
+							<widget class="GtkMenuItem" id="help">
+								<property name="visible">True</property>
+								<property name="label">_Help</property>
+								<property name="use_underline">True</property>
+
+								<child>
+									<widget class="GtkMenu" id="help_menu">
+
+										<child>
+											<widget class="GtkImageMenuItem" id="about1">
+												<property name="visible">True</property>
+												<property name="label">gtk-about</property>
+												<property name="use_stock">True</property>
+												<signal name="activate" handler="on_about1_activate" last_modification_time="Tue, 19 Dec 2006 07:58:27 GMT"/>
+											</widget>
+										</child>
+									</widget>
+								</child>
+							</widget>
+						</child>
 					</widget>
 					<packing>
-					  <property name="padding">0</property>
-					  <property name="expand">False</property>
-					  <property name="fill">False</property>
+						<property name="padding">0</property>
+						<property name="expand">False</property>
+						<property name="fill">False</property>
 					</packing>
-				      </child>
+				</child>
 
-				      <child>
-					<widget class="GtkLabel" id="label72">
-					  <property name="visible">True</property>
-					  <property name="label" translatable="yes">whitespace at end of line</property>
-					  <property name="use_underline">True</property>
-					  <property name="use_markup">False</property>
-					  <property name="justify">GTK_JUSTIFY_LEFT</property>
-					  <property name="wrap">False</property>
-					  <property name="selectable">False</property>
-					  <property name="xalign">0.5</property>
-					  <property name="yalign">0.5</property>
-					  <property name="xpad">0</property>
-					  <property name="ypad">0</property>
-					  <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-					  <property name="width_chars">-1</property>
-					  <property name="single_line_mode">False</property>
-					  <property name="angle">0</property>
+				<child>
+					<widget class="GtkHBox" id="hbox3">
+						<property name="visible">True</property>
+						<property name="homogeneous">False</property>
+						<property name="spacing">0</property>
+
+						<child>
+							<widget class="GtkNotebook" id="notebook2">
+								<property name="border_width">3</property>
+								<property name="visible">True</property>
+								<property name="can_focus">True</property>
+								<property name="show_tabs">True</property>
+								<property name="show_border">True</property>
+								<property name="tab_pos">GTK_POS_TOP</property>
+								<property name="scrollable">False</property>
+								<property name="enable_popup">False</property>
+
+								<child>
+									<widget class="GtkHBox" id="hbox2">
+										<property name="visible">True</property>
+										<property name="homogeneous">False</property>
+										<property name="spacing">0</property>
+
+										<child>
+											<widget class="GtkVButtonBox" id="vbuttonbox2">
+												<property name="border_width">2</property>
+												<property name="visible">True</property>
+												<property name="layout_style">GTK_BUTTONBOX_SPREAD</property>
+												<property name="spacing">0</property>
+
+												<child>
+													<widget class="GtkButton" id="addOkDir">
+														<property name="border_width">2</property>
+														<property name="visible">True</property>
+														<property name="can_default">True</property>
+														<property name="can_focus">True</property>
+														<property name="relief">GTK_RELIEF_NORMAL</property>
+														<property name="focus_on_click">True</property>
+														<signal name="clicked" handler="on_addOkDir_clicked"/>
+
+														<child>
+															<widget class="GtkAlignment" id="alignment1">
+																<property name="visible">True</property>
+																<property name="xalign">0</property>
+																<property name="yalign">0.5</property>
+																<property name="xscale">0</property>
+																<property name="yscale">0</property>
+																<property name="top_padding">0</property>
+																<property name="bottom_padding">0</property>
+																<property name="left_padding">0</property>
+																<property name="right_padding">0</property>
+
+																<child>
+																	<widget class="GtkHBox" id="hbox9">
+																		<property name="visible">True</property>
+																		<property name="homogeneous">False</property>
+																		<property name="spacing">2</property>
+
+																		<child>
+																			<widget class="GtkImage" id="image1">
+																				<property name="visible">True</property>
+																				<property name="stock">gtk-add</property>
+																				<property name="icon_size">4</property>
+																				<property name="xalign">0.5</property>
+																				<property name="yalign">0.5</property>
+																				<property name="xpad">0</property>
+																				<property name="ypad">0</property>
+																			</widget>
+																			<packing>
+																				<property name="padding">0</property>
+																				<property name="expand">False</property>
+																				<property name="fill">False</property>
+																			</packing>
+																		</child>
+
+																		<child>
+																			<widget class="GtkLabel" id="label55">
+																				<property name="visible">True</property>
+																				<property name="label" translatable="yes">Add</property>
+																				<property name="use_underline">True</property>
+																				<property name="use_markup">False</property>
+																				<property name="justify">GTK_JUSTIFY_LEFT</property>
+																				<property name="wrap">False</property>
+																				<property name="selectable">False</property>
+																				<property name="xalign">0.5</property>
+																				<property name="yalign">0.5</property>
+																				<property name="xpad">0</property>
+																				<property name="ypad">0</property>
+																				<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+																				<property name="width_chars">-1</property>
+																				<property name="single_line_mode">False</property>
+																				<property name="angle">0</property>
+																			</widget>
+																			<packing>
+																				<property name="padding">0</property>
+																				<property name="expand">False</property>
+																				<property name="fill">False</property>
+																			</packing>
+																		</child>
+																	</widget>
+																</child>
+															</widget>
+														</child>
+													</widget>
+												</child>
+
+												<child>
+													<widget class="GtkButton" id="removeOkDir">
+														<property name="border_width">2</property>
+														<property name="visible">True</property>
+														<property name="can_default">True</property>
+														<property name="can_focus">True</property>
+														<property name="relief">GTK_RELIEF_NORMAL</property>
+														<property name="focus_on_click">True</property>
+														<signal name="clicked" handler="on_removeOkDir_clicked"/>
+
+														<child>
+															<widget class="GtkAlignment" id="alignment2">
+																<property name="visible">True</property>
+																<property name="xalign">0</property>
+																<property name="yalign">0.5</property>
+																<property name="xscale">0</property>
+																<property name="yscale">0</property>
+																<property name="top_padding">0</property>
+																<property name="bottom_padding">0</property>
+																<property name="left_padding">0</property>
+																<property name="right_padding">0</property>
+
+																<child>
+																	<widget class="GtkHBox" id="hbox10">
+																		<property name="visible">True</property>
+																		<property name="homogeneous">False</property>
+																		<property name="spacing">2</property>
+
+																		<child>
+																			<widget class="GtkImage" id="image2">
+																				<property name="visible">True</property>
+																				<property name="stock">gtk-remove</property>
+																				<property name="icon_size">4</property>
+																				<property name="xalign">0.5</property>
+																				<property name="yalign">0.5</property>
+																				<property name="xpad">0</property>
+																				<property name="ypad">0</property>
+																			</widget>
+																			<packing>
+																				<property name="padding">0</property>
+																				<property name="expand">False</property>
+																				<property name="fill">False</property>
+																			</packing>
+																		</child>
+
+																		<child>
+																			<widget class="GtkLabel" id="label56">
+																				<property name="visible">True</property>
+																				<property name="label" translatable="yes">Remove</property>
+																				<property name="use_underline">True</property>
+																				<property name="use_markup">False</property>
+																				<property name="justify">GTK_JUSTIFY_LEFT</property>
+																				<property name="wrap">False</property>
+																				<property name="selectable">False</property>
+																				<property name="xalign">0.5</property>
+																				<property name="yalign">0.5</property>
+																				<property name="xpad">0</property>
+																				<property name="ypad">0</property>
+																				<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+																				<property name="width_chars">-1</property>
+																				<property name="single_line_mode">False</property>
+																				<property name="angle">0</property>
+																			</widget>
+																			<packing>
+																				<property name="padding">0</property>
+																				<property name="expand">False</property>
+																				<property name="fill">False</property>
+																			</packing>
+																		</child>
+																	</widget>
+																</child>
+															</widget>
+														</child>
+													</widget>
+												</child>
+											</widget>
+											<packing>
+												<property name="padding">0</property>
+												<property name="expand">False</property>
+												<property name="fill">False</property>
+											</packing>
+										</child>
+
+										<child>
+											<widget class="GtkScrolledWindow" id="scrolledwindow3">
+												<property name="visible">True</property>
+												<property name="hscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
+												<property name="vscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
+												<property name="shadow_type">GTK_SHADOW_NONE</property>
+												<property name="window_placement">GTK_CORNER_TOP_LEFT</property>
+
+												<child>
+													<widget class="GtkCList" id="ok_dirs">
+														<property name="border_width">1</property>
+														<property name="visible">True</property>
+														<property name="tooltip" translatable="yes">Directories to search</property>
+														<property name="can_focus">True</property>
+														<property name="n_columns">1</property>
+														<property name="column_widths">80</property>
+														<property name="selection_mode">GTK_SELECTION_MULTIPLE</property>
+														<property name="show_titles">False</property>
+														<property name="shadow_type">GTK_SHADOW_IN</property>
+
+														<child>
+															<placeholder/>
+														</child>
+													</widget>
+												</child>
+											</widget>
+											<packing>
+												<property name="padding">0</property>
+												<property name="expand">True</property>
+												<property name="fill">True</property>
+											</packing>
+										</child>
+
+										<child>
+											<widget class="GtkCheckButton" id="recurseDirs">
+												<property name="visible">True</property>
+												<property name="can_focus">True</property>
+												<property name="label" translatable="yes">recurse?</property>
+												<property name="use_underline">True</property>
+												<property name="relief">GTK_RELIEF_NORMAL</property>
+												<property name="focus_on_click">True</property>
+												<property name="active">True</property>
+												<property name="inconsistent">False</property>
+												<property name="draw_indicator">True</property>
+											</widget>
+											<packing>
+												<property name="padding">0</property>
+												<property name="expand">False</property>
+												<property name="fill">False</property>
+											</packing>
+										</child>
+									</widget>
+									<packing>
+										<property name="tab_expand">False</property>
+										<property name="tab_fill">True</property>
+									</packing>
+								</child>
+
+								<child>
+									<widget class="GtkLabel" id="label11">
+										<property name="visible">True</property>
+										<property name="label" translatable="yes">Search path</property>
+										<property name="use_underline">False</property>
+										<property name="use_markup">False</property>
+										<property name="justify">GTK_JUSTIFY_CENTER</property>
+										<property name="wrap">False</property>
+										<property name="selectable">False</property>
+										<property name="xalign">0.5</property>
+										<property name="yalign">0.5</property>
+										<property name="xpad">0</property>
+										<property name="ypad">0</property>
+										<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+										<property name="width_chars">-1</property>
+										<property name="single_line_mode">False</property>
+										<property name="angle">0</property>
+									</widget>
+									<packing>
+										<property name="type">tab</property>
+									</packing>
+								</child>
+
+								<child>
+									<widget class="GtkHBox" id="hbox3">
+										<property name="visible">True</property>
+										<property name="homogeneous">False</property>
+										<property name="spacing">0</property>
+
+										<child>
+											<widget class="GtkVButtonBox" id="vbuttonbox3">
+												<property name="border_width">2</property>
+												<property name="visible">True</property>
+												<property name="layout_style">GTK_BUTTONBOX_SPREAD</property>
+												<property name="spacing">0</property>
+
+												<child>
+													<widget class="GtkButton" id="addBadDir">
+														<property name="border_width">2</property>
+														<property name="visible">True</property>
+														<property name="can_default">True</property>
+														<property name="can_focus">True</property>
+														<property name="relief">GTK_RELIEF_NORMAL</property>
+														<property name="focus_on_click">True</property>
+														<signal name="clicked" handler="on_addBadDir_clicked"/>
+
+														<child>
+															<widget class="GtkAlignment" id="alignment10">
+																<property name="visible">True</property>
+																<property name="xalign">0</property>
+																<property name="yalign">0.5</property>
+																<property name="xscale">0</property>
+																<property name="yscale">0</property>
+																<property name="top_padding">0</property>
+																<property name="bottom_padding">0</property>
+																<property name="left_padding">0</property>
+																<property name="right_padding">0</property>
+
+																<child>
+																	<widget class="GtkHBox" id="hbox18">
+																		<property name="visible">True</property>
+																		<property name="homogeneous">False</property>
+																		<property name="spacing">2</property>
+
+																		<child>
+																			<widget class="GtkImage" id="image10">
+																				<property name="visible">True</property>
+																				<property name="stock">gtk-add</property>
+																				<property name="icon_size">4</property>
+																				<property name="xalign">0.5</property>
+																				<property name="yalign">0.5</property>
+																				<property name="xpad">0</property>
+																				<property name="ypad">0</property>
+																			</widget>
+																			<packing>
+																				<property name="padding">0</property>
+																				<property name="expand">False</property>
+																				<property name="fill">False</property>
+																			</packing>
+																		</child>
+
+																		<child>
+																			<widget class="GtkLabel" id="label64">
+																				<property name="visible">True</property>
+																				<property name="label" translatable="yes">Add</property>
+																				<property name="use_underline">True</property>
+																				<property name="use_markup">False</property>
+																				<property name="justify">GTK_JUSTIFY_LEFT</property>
+																				<property name="wrap">False</property>
+																				<property name="selectable">False</property>
+																				<property name="xalign">0.5</property>
+																				<property name="yalign">0.5</property>
+																				<property name="xpad">0</property>
+																				<property name="ypad">0</property>
+																				<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+																				<property name="width_chars">-1</property>
+																				<property name="single_line_mode">False</property>
+																				<property name="angle">0</property>
+																			</widget>
+																			<packing>
+																				<property name="padding">0</property>
+																				<property name="expand">False</property>
+																				<property name="fill">False</property>
+																			</packing>
+																		</child>
+																	</widget>
+																</child>
+															</widget>
+														</child>
+													</widget>
+												</child>
+
+												<child>
+													<widget class="GtkButton" id="removeBadDir">
+														<property name="border_width">2</property>
+														<property name="visible">True</property>
+														<property name="can_default">True</property>
+														<property name="can_focus">True</property>
+														<property name="relief">GTK_RELIEF_NORMAL</property>
+														<property name="focus_on_click">True</property>
+														<signal name="clicked" handler="on_removeBadDir_clicked"/>
+
+														<child>
+															<widget class="GtkAlignment" id="alignment11">
+																<property name="visible">True</property>
+																<property name="xalign">0</property>
+																<property name="yalign">0.5</property>
+																<property name="xscale">0</property>
+																<property name="yscale">0</property>
+																<property name="top_padding">0</property>
+																<property name="bottom_padding">0</property>
+																<property name="left_padding">0</property>
+																<property name="right_padding">0</property>
+
+																<child>
+																	<widget class="GtkHBox" id="hbox19">
+																		<property name="visible">True</property>
+																		<property name="homogeneous">False</property>
+																		<property name="spacing">2</property>
+
+																		<child>
+																			<widget class="GtkImage" id="image11">
+																				<property name="visible">True</property>
+																				<property name="stock">gtk-remove</property>
+																				<property name="icon_size">4</property>
+																				<property name="xalign">0.5</property>
+																				<property name="yalign">0.5</property>
+																				<property name="xpad">0</property>
+																				<property name="ypad">0</property>
+																			</widget>
+																			<packing>
+																				<property name="padding">0</property>
+																				<property name="expand">False</property>
+																				<property name="fill">False</property>
+																			</packing>
+																		</child>
+
+																		<child>
+																			<widget class="GtkLabel" id="label65">
+																				<property name="visible">True</property>
+																				<property name="label" translatable="yes">Remove</property>
+																				<property name="use_underline">True</property>
+																				<property name="use_markup">False</property>
+																				<property name="justify">GTK_JUSTIFY_LEFT</property>
+																				<property name="wrap">False</property>
+																				<property name="selectable">False</property>
+																				<property name="xalign">0.5</property>
+																				<property name="yalign">0.5</property>
+																				<property name="xpad">0</property>
+																				<property name="ypad">0</property>
+																				<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+																				<property name="width_chars">-1</property>
+																				<property name="single_line_mode">False</property>
+																				<property name="angle">0</property>
+																			</widget>
+																			<packing>
+																				<property name="padding">0</property>
+																				<property name="expand">False</property>
+																				<property name="fill">False</property>
+																			</packing>
+																		</child>
+																	</widget>
+																</child>
+															</widget>
+														</child>
+													</widget>
+												</child>
+											</widget>
+											<packing>
+												<property name="padding">0</property>
+												<property name="expand">False</property>
+												<property name="fill">True</property>
+											</packing>
+										</child>
+
+										<child>
+											<widget class="GtkScrolledWindow" id="scrolledwindow4">
+												<property name="visible">True</property>
+												<property name="hscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
+												<property name="vscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
+												<property name="shadow_type">GTK_SHADOW_NONE</property>
+												<property name="window_placement">GTK_CORNER_TOP_LEFT</property>
+
+												<child>
+													<widget class="GtkCList" id="bad_dirs">
+														<property name="visible">True</property>
+														<property name="can_focus">True</property>
+														<property name="n_columns">1</property>
+														<property name="column_widths">80</property>
+														<property name="selection_mode">GTK_SELECTION_MULTIPLE</property>
+														<property name="show_titles">True</property>
+														<property name="shadow_type">GTK_SHADOW_IN</property>
+
+														<child>
+															<widget class="GtkLabel" id="label18">
+																<property name="label" translatable="yes">Paths to exclude</property>
+																<property name="use_underline">False</property>
+																<property name="use_markup">False</property>
+																<property name="justify">GTK_JUSTIFY_CENTER</property>
+																<property name="wrap">False</property>
+																<property name="selectable">False</property>
+																<property name="xalign">0.5</property>
+																<property name="yalign">0.5</property>
+																<property name="xpad">0</property>
+																<property name="ypad">0</property>
+																<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+																<property name="width_chars">-1</property>
+																<property name="single_line_mode">False</property>
+																<property name="angle">0</property>
+															</widget>
+														</child>
+													</widget>
+												</child>
+											</widget>
+											<packing>
+												<property name="padding">0</property>
+												<property name="expand">True</property>
+												<property name="fill">True</property>
+											</packing>
+										</child>
+
+										<child>
+											<widget class="GtkVBox" id="vbox3">
+												<property name="visible">True</property>
+												<property name="homogeneous">False</property>
+												<property name="spacing">7</property>
+
+												<child>
+													<widget class="GtkLabel" id="label19">
+														<property name="visible">True</property>
+														<property name="label" translatable="yes">Extra find parameters</property>
+														<property name="use_underline">False</property>
+														<property name="use_markup">False</property>
+														<property name="justify">GTK_JUSTIFY_CENTER</property>
+														<property name="wrap">False</property>
+														<property name="selectable">False</property>
+														<property name="xalign">0.5</property>
+														<property name="yalign">0.5</property>
+														<property name="xpad">0</property>
+														<property name="ypad">0</property>
+														<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+														<property name="width_chars">-1</property>
+														<property name="single_line_mode">False</property>
+														<property name="angle">0</property>
+													</widget>
+													<packing>
+														<property name="padding">0</property>
+														<property name="expand">False</property>
+														<property name="fill">False</property>
+													</packing>
+												</child>
+
+												<child>
+													<widget class="GtkEntry" id="extra_find_params">
+														<property name="visible">True</property>
+														<property name="tooltip" translatable="yes">extra find filtering parameters</property>
+														<property name="can_focus">True</property>
+														<property name="editable">True</property>
+														<property name="visibility">True</property>
+														<property name="max_length">0</property>
+														<property name="text"></property>
+														<property name="has_frame">True</property>
+														<property name="invisible_char">*</property>
+														<property name="activates_default">False</property>
+													</widget>
+													<packing>
+														<property name="padding">0</property>
+														<property name="expand">False</property>
+														<property name="fill">False</property>
+													</packing>
+												</child>
+											</widget>
+											<packing>
+												<property name="padding">0</property>
+												<property name="expand">True</property>
+												<property name="fill">True</property>
+											</packing>
+										</child>
+									</widget>
+									<packing>
+										<property name="tab_expand">False</property>
+										<property name="tab_fill">True</property>
+									</packing>
+								</child>
+
+								<child>
+									<widget class="GtkLabel" id="label12">
+										<property name="visible">True</property>
+										<property name="label" translatable="yes">Advanced search parameters</property>
+										<property name="use_underline">False</property>
+										<property name="use_markup">False</property>
+										<property name="justify">GTK_JUSTIFY_CENTER</property>
+										<property name="wrap">False</property>
+										<property name="selectable">False</property>
+										<property name="xalign">0.5</property>
+										<property name="yalign">0.5</property>
+										<property name="xpad">0</property>
+										<property name="ypad">0</property>
+										<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+										<property name="width_chars">-1</property>
+										<property name="single_line_mode">False</property>
+										<property name="angle">0</property>
+									</widget>
+									<packing>
+										<property name="type">tab</property>
+									</packing>
+								</child>
+							</widget>
+							<packing>
+								<property name="padding">0</property>
+								<property name="expand">True</property>
+								<property name="fill">True</property>
+							</packing>
+						</child>
 					</widget>
 					<packing>
-					  <property name="padding">0</property>
-					  <property name="expand">False</property>
-					  <property name="fill">False</property>
+						<property name="padding">0</property>
+						<property name="expand">False</property>
+						<property name="fill">True</property>
 					</packing>
-				      </child>
-				    </widget>
-				  </child>
-				</widget>
-			      </child>
-			    </widget>
-			    <packing>
-			      <property name="padding">0</property>
-			      <property name="expand">False</property>
-			      <property name="fill">False</property>
-			      <property name="pack_type">GTK_PACK_END</property>
-			    </packing>
-			  </child>
-			</widget>
-			<packing>
-			  <property name="padding">0</property>
-			  <property name="expand">False</property>
-			  <property name="fill">True</property>
-			</packing>
-		      </child>
+				</child>
 
-		      <child>
-			<widget class="GtkScrolledWindow" id="scrolledwindow12">
-			  <property name="visible">True</property>
-			  <property name="hscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-			  <property name="vscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-			  <property name="shadow_type">GTK_SHADOW_NONE</property>
-			  <property name="window_placement">GTK_CORNER_TOP_LEFT</property>
+				<child>
+					<widget class="GtkVPaned" id="vpanes">
+						<property name="border_width">3</property>
+						<property name="visible">True</property>
+						<property name="position">400</property>
 
-			  <child>
-			    <widget class="GtkCList" id="clist_rs">
-			      <property name="border_width">1</property>
-			      <property name="visible">True</property>
-			      <property name="can_focus">True</property>
-			      <property name="n_columns">4</property>
-			      <property name="column_widths">80,80,80,80</property>
-			      <property name="selection_mode">GTK_SELECTION_MULTIPLE</property>
-			      <property name="show_titles">True</property>
-			      <property name="shadow_type">GTK_SHADOW_IN</property>
-			      <signal name="button_press_event" handler="on_selection_menu_button_press_event" last_modification_time="Mon, 18 Dec 2006 19:20:00 GMT"/>
+						<child>
+							<widget class="GtkVBox" id="vbox2">
+								<property name="visible">True</property>
+								<property name="homogeneous">False</property>
+								<property name="spacing">0</property>
 
-			      <child>
-				<widget class="GtkLabel" id="label48">
-				  <property name="label" translatable="yes">Name</property>
-				  <property name="use_underline">False</property>
-				  <property name="use_markup">False</property>
-				  <property name="justify">GTK_JUSTIFY_CENTER</property>
-				  <property name="wrap">False</property>
-				  <property name="selectable">False</property>
-				  <property name="xalign">7.45058015283e-09</property>
-				  <property name="yalign">0.5</property>
-				  <property name="xpad">0</property>
-				  <property name="ypad">0</property>
-				  <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-				  <property name="width_chars">-1</property>
-				  <property name="single_line_mode">False</property>
-				  <property name="angle">0</property>
-				</widget>
-			      </child>
+								<child>
+									<widget class="GtkNotebook" id="fslint_functions">
+										<property name="visible">True</property>
+										<property name="can_focus">True</property>
+										<property name="show_tabs">True</property>
+										<property name="show_border">True</property>
+										<property name="tab_pos">GTK_POS_LEFT</property>
+										<property name="scrollable">True</property>
+										<property name="enable_popup">False</property>
+										<signal name="switch_page" handler="on_fslint_functions_switch_page"/>
 
-			      <child>
-				<widget class="GtkLabel" id="label49">
-				  <property name="label" translatable="yes">Directory</property>
-				  <property name="use_underline">False</property>
-				  <property name="use_markup">False</property>
-				  <property name="justify">GTK_JUSTIFY_CENTER</property>
-				  <property name="wrap">False</property>
-				  <property name="selectable">False</property>
-				  <property name="xalign">7.45058015283e-09</property>
-				  <property name="yalign">0.5</property>
-				  <property name="xpad">0</property>
-				  <property name="ypad">0</property>
-				  <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-				  <property name="width_chars">-1</property>
-				  <property name="single_line_mode">False</property>
-				  <property name="angle">0</property>
-				</widget>
-			      </child>
+										<child>
+											<widget class="GtkVBox" id="vbox1">
+												<property name="visible">True</property>
+												<property name="homogeneous">False</property>
+												<property name="spacing">0</property>
 
-			      <child>
-				<widget class="GtkLabel" id="label50">
-				  <property name="label" translatable="yes">Size</property>
-				  <property name="use_underline">False</property>
-				  <property name="use_markup">False</property>
-				  <property name="justify">GTK_JUSTIFY_CENTER</property>
-				  <property name="wrap">False</property>
-				  <property name="selectable">False</property>
-				  <property name="xalign">7.45058015283e-09</property>
-				  <property name="yalign">0.5</property>
-				  <property name="xpad">0</property>
-				  <property name="ypad">0</property>
-				  <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-				  <property name="width_chars">-1</property>
-				  <property name="single_line_mode">False</property>
-				  <property name="angle">0</property>
-				</widget>
-			      </child>
+												<child>
+													<widget class="GtkHBox" id="hbox31">
+														<property name="visible">True</property>
+														<property name="homogeneous">False</property>
+														<property name="spacing">0</property>
 
-			      <child>
-				<widget class="GtkLabel" id="label51">
-				  <property name="label" translatable="yes">Date</property>
-				  <property name="use_underline">False</property>
-				  <property name="use_markup">False</property>
-				  <property name="justify">GTK_JUSTIFY_CENTER</property>
-				  <property name="wrap">False</property>
-				  <property name="selectable">False</property>
-				  <property name="xalign">7.45058015283e-09</property>
-				  <property name="yalign">0.5</property>
-				  <property name="xpad">0</property>
-				  <property name="ypad">0</property>
-				  <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-				  <property name="width_chars">-1</property>
-				  <property name="single_line_mode">False</property>
-				  <property name="angle">0</property>
-				</widget>
-			      </child>
-			    </widget>
-			  </child>
-			</widget>
-			<packing>
-			  <property name="padding">0</property>
-			  <property name="expand">True</property>
-			  <property name="fill">True</property>
-			</packing>
-		      </child>
-		    </widget>
-		    <packing>
-		      <property name="tab_expand">False</property>
-		      <property name="tab_fill">True</property>
-		    </packing>
-		  </child>
+														<child>
+															<widget class="GtkLabel" id="label77">
+																<property name="visible">True</property>
+																<property name="label" translatable="yes">Minimum file size:</property>
+																<property name="use_underline">False</property>
+																<property name="use_markup">False</property>
+																<property name="justify">GTK_JUSTIFY_LEFT</property>
+																<property name="wrap">False</property>
+																<property name="selectable">False</property>
+																<property name="xalign">0.5</property>
+																<property name="yalign">0.5</property>
+																<property name="xpad">0</property>
+																<property name="ypad">0</property>
+																<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+																<property name="width_chars">-1</property>
+																<property name="single_line_mode">False</property>
+																<property name="angle">0</property>
+															</widget>
+															<packing>
+																<property name="padding">0</property>
+																<property name="expand">False</property>
+																<property name="fill">False</property>
+															</packing>
+														</child>
 
-		  <child>
-		    <widget class="GtkLabel" id="rs">
-		      <property name="visible">True</property>
-		      <property name="label" translatable="yes">Redundant whitespace</property>
-		      <property name="use_underline">False</property>
-		      <property name="use_markup">False</property>
-		      <property name="justify">GTK_JUSTIFY_CENTER</property>
-		      <property name="wrap">False</property>
-		      <property name="selectable">False</property>
-		      <property name="xalign">0.5</property>
-		      <property name="yalign">0.5</property>
-		      <property name="xpad">0</property>
-		      <property name="ypad">0</property>
-		      <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-		      <property name="width_chars">-1</property>
-		      <property name="single_line_mode">False</property>
-		      <property name="angle">0</property>
-		    </widget>
-		    <packing>
-		      <property name="type">tab</property>
-		    </packing>
-		  </child>
-		</widget>
-		<packing>
-		  <property name="padding">3</property>
-		  <property name="expand">True</property>
-		  <property name="fill">True</property>
-		</packing>
-	      </child>
+														<child>
+															<widget class="GtkEntry" id="min_size">
+																<property name="visible">True</property>
+																<property name="tooltip" translatable="yes">Using find -size syntax</property>
+																<property name="can_focus">True</property>
+																<property name="editable">True</property>
+																<property name="visibility">True</property>
+																<property name="max_length">0</property>
+																<property name="text">1</property>
+																<property name="has_frame">True</property>
+																<property name="invisible_char">●</property>
+																<property name="activates_default">False</property>
+															</widget>
+															<packing>
+																<property name="padding">0</property>
+																<property name="expand">True</property>
+																<property name="fill">True</property>
+															</packing>
+														</child>
+													</widget>
+													<packing>
+														<property name="padding">0</property>
+														<property name="expand">False</property>
+														<property name="fill">False</property>
+													</packing>
+												</child>
 
-	      <child>
-		<widget class="GtkHBox" id="hbox20">
-		  <property name="visible">True</property>
-		  <property name="homogeneous">False</property>
-		  <property name="spacing">0</property>
+												<child>
+													<widget class="GtkScrolledWindow" id="scrolledwindow1">
+														<property name="visible">True</property>
+														<property name="hscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
+														<property name="vscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
+														<property name="shadow_type">GTK_SHADOW_NONE</property>
+														<property name="window_placement">GTK_CORNER_TOP_LEFT</property>
 
-		  <child>
-		    <widget class="GtkHBox" id="control_buttons">
-		      <property name="visible">True</property>
-		      <property name="homogeneous">False</property>
-		      <property name="spacing">0</property>
-		      <signal name="key_press_event" handler="on_control_buttons_keypress" last_modification_time="Wed, 15 Jul 2009 10:32:48 GMT"/>
+														<child>
+															<widget class="GtkCList" id="clist_dups">
+																<property name="border_width">1</property>
+																<property name="visible">True</property>
+																<property name="can_focus">True</property>
+																<property name="n_columns">3</property>
+																<property name="column_widths">80,180,80</property>
+																<property name="selection_mode">GTK_SELECTION_MULTIPLE</property>
+																<property name="show_titles">True</property>
+																<property name="shadow_type">GTK_SHADOW_IN</property>
+																<signal name="button_press_event" handler="on_selection_menu_button_press_event" last_modification_time="Tue, 12 Dec 2006 18:44:16 GMT"/>
 
-		      <child>
-			<widget class="GtkButton" id="find">
-			  <property name="visible">True</property>
-			  <property name="can_default">True</property>
-			  <property name="can_focus">True</property>
-			  <property name="relief">GTK_RELIEF_NORMAL</property>
-			  <property name="focus_on_click">True</property>
-			  <signal name="clicked" handler="on_find_clicked"/>
+																<child>
+																	<widget class="GtkLabel" id="label15">
+																		<property name="label" translatable="yes">Name</property>
+																		<property name="use_underline">False</property>
+																		<property name="use_markup">False</property>
+																		<property name="justify">GTK_JUSTIFY_CENTER</property>
+																		<property name="wrap">False</property>
+																		<property name="selectable">False</property>
+																		<property name="xalign">7.45058015283e-09</property>
+																		<property name="yalign">0.5</property>
+																		<property name="xpad">0</property>
+																		<property name="ypad">0</property>
+																		<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+																		<property name="width_chars">-1</property>
+																		<property name="single_line_mode">False</property>
+																		<property name="angle">0</property>
+																	</widget>
+																</child>
 
-			  <child>
-			    <widget class="GtkAlignment" id="alignment12">
-			      <property name="visible">True</property>
-			      <property name="xalign">0.5</property>
-			      <property name="yalign">0.5</property>
-			      <property name="xscale">0</property>
-			      <property name="yscale">0</property>
-			      <property name="top_padding">0</property>
-			      <property name="bottom_padding">0</property>
-			      <property name="left_padding">0</property>
-			      <property name="right_padding">2</property>
+																<child>
+																	<widget class="GtkLabel" id="label15m">
+																		<property name="label" translatable="yes">Directory</property>
+																		<property name="use_underline">False</property>
+																		<property name="use_markup">False</property>
+																		<property name="justify">GTK_JUSTIFY_CENTER</property>
+																		<property name="wrap">False</property>
+																		<property name="selectable">False</property>
+																		<property name="xalign">7.45058015283e-09</property>
+																		<property name="yalign">0.5</property>
+																		<property name="xpad">0</property>
+																		<property name="ypad">0</property>
+																		<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+																		<property name="width_chars">-1</property>
+																		<property name="single_line_mode">False</property>
+																		<property name="angle">0</property>
+																	</widget>
+																</child>
 
-			      <child>
-				<widget class="GtkHBox" id="hbox21">
-				  <property name="visible">True</property>
-				  <property name="homogeneous">False</property>
-				  <property name="spacing">2</property>
+																<child>
+																	<widget class="GtkLabel" id="label16">
+																		<property name="label" translatable="yes">Date</property>
+																		<property name="use_underline">False</property>
+																		<property name="use_markup">False</property>
+																		<property name="justify">GTK_JUSTIFY_LEFT</property>
+																		<property name="wrap">False</property>
+																		<property name="selectable">False</property>
+																		<property name="xalign">7.45058015283e-09</property>
+																		<property name="yalign">0.5</property>
+																		<property name="xpad">0</property>
+																		<property name="ypad">0</property>
+																		<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+																		<property name="width_chars">-1</property>
+																		<property name="single_line_mode">False</property>
+																		<property name="angle">0</property>
+																	</widget>
+																</child>
+															</widget>
+														</child>
+													</widget>
+													<packing>
+														<property name="padding">0</property>
+														<property name="expand">True</property>
+														<property name="fill">True</property>
+													</packing>
+												</child>
+											</widget>
+											<packing>
+												<property name="tab_expand">False</property>
+												<property name="tab_fill">True</property>
+											</packing>
+										</child>
 
-				  <child>
-				    <widget class="GtkImage" id="image12">
-				      <property name="visible">True</property>
-				      <property name="stock">gtk-find</property>
-				      <property name="icon_size">4</property>
-				      <property name="xalign">0.5</property>
-				      <property name="yalign">0.5</property>
-				      <property name="xpad">0</property>
-				      <property name="ypad">0</property>
-				    </widget>
-				    <packing>
-				      <property name="padding">0</property>
-				      <property name="expand">False</property>
-				      <property name="fill">False</property>
-				    </packing>
-				  </child>
+										<child>
+											<widget class="GtkLabel" id="dup">
+												<property name="visible">True</property>
+												<property name="label" translatable="yes">Duplicates</property>
+												<property name="use_underline">False</property>
+												<property name="use_markup">False</property>
+												<property name="justify">GTK_JUSTIFY_CENTER</property>
+												<property name="wrap">False</property>
+												<property name="selectable">False</property>
+												<property name="xalign">0.5</property>
+												<property name="yalign">0.5</property>
+												<property name="xpad">0</property>
+												<property name="ypad">0</property>
+												<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+												<property name="width_chars">-1</property>
+												<property name="single_line_mode">False</property>
+												<property name="angle">0</property>
+											</widget>
+											<packing>
+												<property name="type">tab</property>
+											</packing>
+										</child>
 
-				  <child>
-				    <widget class="GtkLabel" id="label66">
-				      <property name="visible">True</property>
-				      <property name="label" translatable="yes">Find</property>
-				      <property name="use_underline">True</property>
-				      <property name="use_markup">False</property>
-				      <property name="justify">GTK_JUSTIFY_LEFT</property>
-				      <property name="wrap">False</property>
-				      <property name="selectable">False</property>
-				      <property name="xalign">0.5</property>
-				      <property name="yalign">0.5</property>
-				      <property name="xpad">0</property>
-				      <property name="ypad">0</property>
-				      <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-				      <property name="width_chars">-1</property>
-				      <property name="single_line_mode">False</property>
-				      <property name="angle">0</property>
-				    </widget>
-				    <packing>
-				      <property name="padding">0</property>
-				      <property name="expand">False</property>
-				      <property name="fill">False</property>
-				    </packing>
-				  </child>
-				</widget>
-			      </child>
-			    </widget>
-			  </child>
-			</widget>
-			<packing>
-			  <property name="padding">1</property>
-			  <property name="expand">False</property>
-			  <property name="fill">False</property>
-			</packing>
-		      </child>
+										<child>
+											<widget class="GtkHBox" id="hbox22">
+												<property name="visible">True</property>
+												<property name="homogeneous">False</property>
+												<property name="spacing">0</property>
 
-		      <child>
-			<widget class="GtkButton" id="stop">
-			  <property name="can_default">True</property>
-			  <property name="can_focus">True</property>
-			  <property name="relief">GTK_RELIEF_NORMAL</property>
-			  <property name="focus_on_click">True</property>
-			  <signal name="clicked" handler="on_stop_clicked" last_modification_time="Thu, 06 Mar 2003 19:09:18 GMT"/>
+												<child>
+													<widget class="GtkVPaned" id="pkg_panes">
+														<property name="visible">True</property>
+														<property name="can_focus">True</property>
+														<property name="position">250</property>
 
-			  <child>
-			    <widget class="GtkAlignment" id="alignment4">
-			      <property name="visible">True</property>
-			      <property name="xalign">0.5</property>
-			      <property name="yalign">0.5</property>
-			      <property name="xscale">0</property>
-			      <property name="yscale">0</property>
-			      <property name="top_padding">0</property>
-			      <property name="bottom_padding">0</property>
-			      <property name="left_padding">0</property>
-			      <property name="right_padding">2</property>
+														<child>
+															<widget class="GtkScrolledWindow" id="scrolledwindow13">
+																<property name="visible">True</property>
+																<property name="can_focus">True</property>
+																<property name="hscrollbar_policy">GTK_POLICY_NEVER</property>
+																<property name="vscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
+																<property name="shadow_type">GTK_SHADOW_NONE</property>
+																<property name="window_placement">GTK_CORNER_TOP_LEFT</property>
 
-			      <child>
-				<widget class="GtkHBox" id="hbox12">
-				  <property name="visible">True</property>
-				  <property name="homogeneous">False</property>
-				  <property name="spacing">2</property>
+																<child>
+																	<widget class="GtkCList" id="clist_pkgs">
+																		<property name="border_width">1</property>
+																		<property name="visible">True</property>
+																		<property name="can_focus">True</property>
+																		<property name="n_columns">4</property>
+																		<property name="column_widths">80,80,80,80</property>
+																		<property name="selection_mode">GTK_SELECTION_MULTIPLE</property>
+																		<property name="show_titles">True</property>
+																		<property name="shadow_type">GTK_SHADOW_IN</property>
+																		<signal name="button_press_event" handler="on_clist_pkgs_button_press" last_modification_time="Wed, 11 Jan 2006 08:25:01 GMT"/>
+																		<signal name="key_press_event" handler="on_clist_pkgs_key_press" last_modification_time="Wed, 11 Jan 2006 08:54:05 GMT"/>
+																		<signal name="select_row" handler="on_clist_pkgs_selection_changed" last_modification_time="Wed, 11 Jan 2006 08:54:05 GMT"/>
+																		<signal name="click_column" handler="on_clist_pkgs_click_column" last_modification_time="Wed, 18 Jan 2006 08:45:37 GMT"/>
 
-				  <child>
-				    <widget class="GtkImage" id="image4">
-				      <property name="visible">True</property>
-				      <property name="stock">gtk-stop</property>
-				      <property name="icon_size">4</property>
-				      <property name="xalign">0.5</property>
-				      <property name="yalign">0.5</property>
-				      <property name="xpad">0</property>
-				      <property name="ypad">0</property>
-				    </widget>
-				    <packing>
-				      <property name="padding">0</property>
-				      <property name="expand">False</property>
-				      <property name="fill">False</property>
-				    </packing>
-				  </child>
+																		<child>
+																			<widget class="GtkLabel" id="label68">
+																				<property name="label" translatable="yes">Name</property>
+																				<property name="use_underline">False</property>
+																				<property name="use_markup">False</property>
+																				<property name="justify">GTK_JUSTIFY_CENTER</property>
+																				<property name="wrap">False</property>
+																				<property name="selectable">False</property>
+																				<property name="xalign">0</property>
+																				<property name="yalign">0.5</property>
+																				<property name="xpad">0</property>
+																				<property name="ypad">0</property>
+																				<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+																				<property name="width_chars">-1</property>
+																				<property name="single_line_mode">False</property>
+																				<property name="angle">0</property>
+																			</widget>
+																		</child>
 
-				  <child>
-				    <widget class="GtkLabel" id="label58">
-				      <property name="visible">True</property>
-				      <property name="label" translatable="yes">Stop</property>
-				      <property name="use_underline">True</property>
-				      <property name="use_markup">False</property>
-				      <property name="justify">GTK_JUSTIFY_LEFT</property>
-				      <property name="wrap">False</property>
-				      <property name="selectable">False</property>
-				      <property name="xalign">0.5</property>
-				      <property name="yalign">0.5</property>
-				      <property name="xpad">0</property>
-				      <property name="ypad">0</property>
-				      <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-				      <property name="width_chars">-1</property>
-				      <property name="single_line_mode">False</property>
-				      <property name="angle">0</property>
-				    </widget>
-				    <packing>
-				      <property name="padding">0</property>
-				      <property name="expand">False</property>
-				      <property name="fill">False</property>
-				    </packing>
-				  </child>
-				</widget>
-			      </child>
-			    </widget>
-			  </child>
-			</widget>
-			<packing>
-			  <property name="padding">1</property>
-			  <property name="expand">False</property>
-			  <property name="fill">False</property>
-			</packing>
-		      </child>
+																		<child>
+																			<widget class="GtkLabel" id="label69">
+																				<property name="label" translatable="yes">Size</property>
+																				<property name="use_underline">False</property>
+																				<property name="use_markup">False</property>
+																				<property name="justify">GTK_JUSTIFY_RIGHT</property>
+																				<property name="wrap">False</property>
+																				<property name="selectable">False</property>
+																				<property name="xalign">7.45058015283e-09</property>
+																				<property name="yalign">0.5</property>
+																				<property name="xpad">0</property>
+																				<property name="ypad">0</property>
+																				<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+																				<property name="width_chars">-1</property>
+																				<property name="single_line_mode">False</property>
+																				<property name="angle">0</property>
+																			</widget>
+																		</child>
 
-		      <child>
-			<widget class="GtkButton" id="pause">
-			  <property name="can_default">True</property>
-			  <property name="can_focus">True</property>
-			  <property name="relief">GTK_RELIEF_NORMAL</property>
-			  <property name="focus_on_click">True</property>
-			  <signal name="clicked" handler="on_pause_clicked" last_modification_time="Tue, 07 Jul 2009 21:28:03 GMT"/>
+																		<child>
+																			<widget class="GtkLabel" id="label70">
+																				<property name="label">Size_for_Sort</property>
+																				<property name="use_underline">False</property>
+																				<property name="use_markup">False</property>
+																				<property name="justify">GTK_JUSTIFY_RIGHT</property>
+																				<property name="wrap">False</property>
+																				<property name="selectable">False</property>
+																				<property name="xalign">7.45058015283e-09</property>
+																				<property name="yalign">0.5</property>
+																				<property name="xpad">0</property>
+																				<property name="ypad">0</property>
+																				<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+																				<property name="width_chars">-1</property>
+																				<property name="single_line_mode">False</property>
+																				<property name="angle">0</property>
+																			</widget>
+																		</child>
 
-			  <child>
-			    <widget class="GtkAlignment" id="alignment17">
-			      <property name="visible">True</property>
-			      <property name="xalign">0.5</property>
-			      <property name="yalign">0.5</property>
-			      <property name="xscale">0</property>
-			      <property name="yscale">0</property>
-			      <property name="top_padding">0</property>
-			      <property name="bottom_padding">0</property>
-			      <property name="left_padding">0</property>
-			      <property name="right_padding">2</property>
+																		<child>
+																			<widget class="GtkLabel" id="label71">
+																				<property name="label">Selection_for_Sort</property>
+																				<property name="use_underline">False</property>
+																				<property name="use_markup">False</property>
+																				<property name="justify">GTK_JUSTIFY_RIGHT</property>
+																				<property name="wrap">False</property>
+																				<property name="selectable">False</property>
+																				<property name="xalign">7.45058015283e-09</property>
+																				<property name="yalign">0.5</property>
+																				<property name="xpad">0</property>
+																				<property name="ypad">0</property>
+																				<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+																				<property name="width_chars">-1</property>
+																				<property name="single_line_mode">False</property>
+																				<property name="angle">0</property>
+																			</widget>
+																		</child>
+																	</widget>
+																</child>
+															</widget>
+															<packing>
+																<property name="shrink">True</property>
+																<property name="resize">False</property>
+															</packing>
+														</child>
 
-			      <child>
-				<widget class="GtkHBox" id="hbox29">
-				  <property name="visible">True</property>
-				  <property name="homogeneous">False</property>
-				  <property name="spacing">2</property>
+														<child>
+															<widget class="GtkScrolledWindow" id="scrolledwindow15">
+																<property name="visible">True</property>
+																<property name="can_focus">True</property>
+																<property name="hscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
+																<property name="vscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
+																<property name="shadow_type">GTK_SHADOW_IN</property>
+																<property name="window_placement">GTK_CORNER_TOP_LEFT</property>
 
-				  <child>
-				    <widget class="GtkImage" id="image17">
-				      <property name="visible">True</property>
-				      <property name="stock">gtk-media-pause</property>
-				      <property name="icon_size">4</property>
-				      <property name="xalign">0.5</property>
-				      <property name="yalign">0.5</property>
-				      <property name="xpad">0</property>
-				      <property name="ypad">0</property>
-				    </widget>
-				    <packing>
-				      <property name="padding">0</property>
-				      <property name="expand">False</property>
-				      <property name="fill">False</property>
-				    </packing>
-				  </child>
+																<child>
+																	<widget class="GtkTextView" id="pkg_info">
+																		<property name="visible">True</property>
+																		<property name="can_focus">True</property>
+																		<property name="editable">False</property>
+																		<property name="overwrite">False</property>
+																		<property name="accepts_tab">True</property>
+																		<property name="justification">GTK_JUSTIFY_LEFT</property>
+																		<property name="wrap_mode">GTK_WRAP_WORD</property>
+																		<property name="cursor_visible">True</property>
+																		<property name="pixels_above_lines">0</property>
+																		<property name="pixels_below_lines">0</property>
+																		<property name="pixels_inside_wrap">0</property>
+																		<property name="left_margin">0</property>
+																		<property name="right_margin">0</property>
+																		<property name="indent">0</property>
+																		<property name="text" translatable="yes"></property>
+																	</widget>
+																</child>
+															</widget>
+															<packing>
+																<property name="shrink">True</property>
+																<property name="resize">True</property>
+															</packing>
+														</child>
+													</widget>
+													<packing>
+														<property name="padding">0</property>
+														<property name="expand">True</property>
+														<property name="fill">True</property>
+													</packing>
+												</child>
+											</widget>
+											<packing>
+												<property name="tab_expand">False</property>
+												<property name="tab_fill">True</property>
+											</packing>
+										</child>
 
-				  <child>
-				    <widget class="GtkLabel" id="label75">
-				      <property name="visible">True</property>
-				      <property name="label" translatable="yes">Pause</property>
-				      <property name="use_underline">True</property>
-				      <property name="use_markup">False</property>
-				      <property name="justify">GTK_JUSTIFY_LEFT</property>
-				      <property name="wrap">False</property>
-				      <property name="selectable">False</property>
-				      <property name="xalign">0.5</property>
-				      <property name="yalign">0.5</property>
-				      <property name="xpad">0</property>
-				      <property name="ypad">0</property>
-				      <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-				      <property name="width_chars">-1</property>
-				      <property name="single_line_mode">False</property>
-				      <property name="angle">0</property>
-				    </widget>
-				    <packing>
-				      <property name="padding">0</property>
-				      <property name="expand">False</property>
-				      <property name="fill">False</property>
-				    </packing>
-				  </child>
-				</widget>
-			      </child>
-			    </widget>
-			  </child>
-			</widget>
-			<packing>
-			  <property name="padding">1</property>
-			  <property name="expand">False</property>
-			  <property name="fill">False</property>
-			</packing>
-		      </child>
+										<child>
+											<widget class="GtkLabel" id="lblPackages">
+												<property name="visible">True</property>
+												<property name="label" translatable="yes">Installed packages</property>
+												<property name="use_underline">False</property>
+												<property name="use_markup">False</property>
+												<property name="justify">GTK_JUSTIFY_LEFT</property>
+												<property name="wrap">False</property>
+												<property name="selectable">False</property>
+												<property name="xalign">0.5</property>
+												<property name="yalign">0.5</property>
+												<property name="xpad">0</property>
+												<property name="ypad">0</property>
+												<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+												<property name="width_chars">-1</property>
+												<property name="single_line_mode">False</property>
+												<property name="angle">0</property>
+											</widget>
+											<packing>
+												<property name="type">tab</property>
+											</packing>
+										</child>
 
-		      <child>
-			<widget class="GtkButton" id="resume">
-			  <property name="can_default">True</property>
-			  <property name="can_focus">True</property>
-			  <property name="relief">GTK_RELIEF_NORMAL</property>
-			  <property name="focus_on_click">True</property>
-			  <signal name="clicked" handler="on_pause_clicked" last_modification_time="Tue, 07 Jul 2009 21:28:33 GMT"/>
+										<child>
+											<widget class="GtkVBox" id="vbox4">
+												<property name="visible">True</property>
+												<property name="homogeneous">False</property>
+												<property name="spacing">0</property>
 
-			  <child>
-			    <widget class="GtkAlignment" id="alignment18">
-			      <property name="visible">True</property>
-			      <property name="xalign">0.5</property>
-			      <property name="yalign">0.5</property>
-			      <property name="xscale">0</property>
-			      <property name="yscale">0</property>
-			      <property name="top_padding">0</property>
-			      <property name="bottom_padding">0</property>
-			      <property name="left_padding">0</property>
-			      <property name="right_padding">2</property>
+												<child>
+													<widget class="GtkHBox" id="hbox4">
+														<property name="visible">True</property>
+														<property name="homogeneous">False</property>
+														<property name="spacing">0</property>
 
-			      <child>
-				<widget class="GtkHBox" id="hbox30">
-				  <property name="visible">True</property>
-				  <property name="homogeneous">False</property>
-				  <property name="spacing">2</property>
+														<child>
+															<widget class="GtkHBox" id="hbox5">
+																<property name="visible">True</property>
+																<property name="homogeneous">False</property>
+																<property name="spacing">0</property>
 
-				  <child>
-				    <widget class="GtkImage" id="image18">
-				      <property name="visible">True</property>
-				      <property name="stock">gtk-media-play</property>
-				      <property name="icon_size">4</property>
-				      <property name="xalign">0.5</property>
-				      <property name="yalign">0.5</property>
-				      <property name="xpad">0</property>
-				      <property name="ypad">0</property>
-				    </widget>
-				    <packing>
-				      <property name="padding">0</property>
-				      <property name="expand">False</property>
-				      <property name="fill">False</property>
-				    </packing>
-				  </child>
+																<child>
+																	<widget class="GtkLabel" id="lbl_findnl_sensitivity">
+																		<property name="visible">True</property>
+																		<property name="label" translatable="yes">Sensitivity=</property>
+																		<property name="use_underline">False</property>
+																		<property name="use_markup">False</property>
+																		<property name="justify">GTK_JUSTIFY_CENTER</property>
+																		<property name="wrap">False</property>
+																		<property name="selectable">False</property>
+																		<property name="xalign">0.5</property>
+																		<property name="yalign">0.5</property>
+																		<property name="xpad">0</property>
+																		<property name="ypad">0</property>
+																		<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+																		<property name="width_chars">-1</property>
+																		<property name="single_line_mode">False</property>
+																		<property name="angle">0</property>
+																	</widget>
+																	<packing>
+																		<property name="padding">0</property>
+																		<property name="expand">False</property>
+																		<property name="fill">False</property>
+																	</packing>
+																</child>
 
-				  <child>
-				    <widget class="GtkLabel" id="label76">
-				      <property name="visible">True</property>
-				      <property name="label" translatable="yes">Resume</property>
-				      <property name="use_underline">True</property>
-				      <property name="use_markup">False</property>
-				      <property name="justify">GTK_JUSTIFY_LEFT</property>
-				      <property name="wrap">False</property>
-				      <property name="selectable">False</property>
-				      <property name="xalign">0.5</property>
-				      <property name="yalign">0.5</property>
-				      <property name="xpad">0</property>
-				      <property name="ypad">0</property>
-				      <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-				      <property name="width_chars">-1</property>
-				      <property name="single_line_mode">False</property>
-				      <property name="angle">0</property>
-				    </widget>
-				    <packing>
-				      <property name="padding">0</property>
-				      <property name="expand">False</property>
-				      <property name="fill">False</property>
-				    </packing>
-				  </child>
-				</widget>
-			      </child>
-			    </widget>
-			  </child>
-			</widget>
-			<packing>
-			  <property name="padding">1</property>
-			  <property name="expand">False</property>
-			  <property name="fill">False</property>
-			</packing>
-		      </child>
-		    </widget>
-		    <packing>
-		      <property name="padding">0</property>
-		      <property name="expand">True</property>
-		      <property name="fill">True</property>
-		    </packing>
-		  </child>
+																<child>
+																	<widget class="GtkHScale" id="hscale_findnl_level">
+																		<property name="visible">True</property>
+																		<property name="can_focus">True</property>
+																		<property name="draw_value">True</property>
+																		<property name="value_pos">GTK_POS_LEFT</property>
+																		<property name="digits">0</property>
+																		<property name="update_policy">GTK_UPDATE_CONTINUOUS</property>
+																		<property name="inverted">False</property>
+																		<property name="adjustment">2 1 5 1 1 1</property>
+																	</widget>
+																	<packing>
+																		<property name="padding">0</property>
+																		<property name="expand">True</property>
+																		<property name="fill">True</property>
+																	</packing>
+																</child>
 
-		  <child>
-		    <widget class="GtkHButtonBox" id="action_buttons">
-		      <property name="visible">True</property>
-		      <property name="layout_style">GTK_BUTTONBOX_END</property>
-		      <property name="spacing">2</property>
+																<child>
+																	<widget class="GtkCheckButton" id="chk_findu8">
+																		<property name="visible">True</property>
+																		<property name="can_focus">True</property>
+																		<property name="label" translatable="yes">invalid UTF8 mode?</property>
+																		<property name="use_underline">True</property>
+																		<property name="relief">GTK_RELIEF_NORMAL</property>
+																		<property name="focus_on_click">True</property>
+																		<property name="active">False</property>
+																		<property name="inconsistent">False</property>
+																		<property name="draw_indicator">True</property>
+																		<signal name="toggled" handler="on_chk_findu8_toggled" last_modification_time="Tue, 30 Aug 2005 17:37:33 GMT"/>
+																	</widget>
+																	<packing>
+																		<property name="padding">0</property>
+																		<property name="expand">False</property>
+																		<property name="fill">False</property>
+																		<property name="pack_type">GTK_PACK_END</property>
+																	</packing>
+																</child>
+															</widget>
+															<packing>
+																<property name="padding">1</property>
+																<property name="expand">True</property>
+																<property name="fill">True</property>
+															</packing>
+														</child>
+													</widget>
+													<packing>
+														<property name="padding">2</property>
+														<property name="expand">False</property>
+														<property name="fill">False</property>
+													</packing>
+												</child>
 
-		      <child>
-			<widget class="GtkButton" id="selection">
-			  <property name="visible">True</property>
-			  <property name="can_default">True</property>
-			  <property name="can_focus">True</property>
-			  <property name="relief">GTK_RELIEF_NORMAL</property>
-			  <property name="focus_on_click">True</property>
-			  <signal name="clicked" handler="on_selection_clicked" last_modification_time="Mon, 18 Dec 2006 08:20:59 GMT"/>
+												<child>
+													<widget class="GtkScrolledWindow" id="scrolledwindow5">
+														<property name="visible">True</property>
+														<property name="hscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
+														<property name="vscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
+														<property name="shadow_type">GTK_SHADOW_NONE</property>
+														<property name="window_placement">GTK_CORNER_TOP_LEFT</property>
 
-			  <child>
-			    <widget class="GtkAlignment" id="alignment5">
-			      <property name="visible">True</property>
-			      <property name="xalign">0.5</property>
-			      <property name="yalign">0.5</property>
-			      <property name="xscale">0</property>
-			      <property name="yscale">0</property>
-			      <property name="top_padding">0</property>
-			      <property name="bottom_padding">0</property>
-			      <property name="left_padding">0</property>
-			      <property name="right_padding">0</property>
+														<child>
+															<widget class="GtkCList" id="clist_nl">
+																<property name="border_width">1</property>
+																<property name="visible">True</property>
+																<property name="can_focus">True</property>
+																<property name="n_columns">2</property>
+																<property name="column_widths">80,80</property>
+																<property name="selection_mode">GTK_SELECTION_MULTIPLE</property>
+																<property name="show_titles">True</property>
+																<property name="shadow_type">GTK_SHADOW_IN</property>
+																<signal name="button_press_event" handler="on_selection_menu_button_press_event" last_modification_time="Mon, 18 Dec 2006 19:11:43 GMT"/>
 
-			      <child>
-				<widget class="GtkHBox" id="hbox13">
-				  <property name="visible">True</property>
-				  <property name="homogeneous">False</property>
-				  <property name="spacing">2</property>
+																<child>
+																	<widget class="GtkLabel" id="label20">
+																		<property name="label" translatable="yes">Name</property>
+																		<property name="use_underline">False</property>
+																		<property name="use_markup">False</property>
+																		<property name="justify">GTK_JUSTIFY_CENTER</property>
+																		<property name="wrap">False</property>
+																		<property name="selectable">False</property>
+																		<property name="xalign">7.45058015283e-09</property>
+																		<property name="yalign">0.5</property>
+																		<property name="xpad">0</property>
+																		<property name="ypad">0</property>
+																		<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+																		<property name="width_chars">-1</property>
+																		<property name="single_line_mode">False</property>
+																		<property name="angle">0</property>
+																	</widget>
+																</child>
 
-				  <child>
-				    <widget class="GtkImage" id="image5">
-				      <property name="visible">True</property>
-				      <property name="stock">gtk-index</property>
-				      <property name="icon_size">4</property>
-				      <property name="xalign">0.5</property>
-				      <property name="yalign">0.5</property>
-				      <property name="xpad">0</property>
-				      <property name="ypad">0</property>
-				    </widget>
-				    <packing>
-				      <property name="padding">0</property>
-				      <property name="expand">False</property>
-				      <property name="fill">False</property>
-				    </packing>
-				  </child>
+																<child>
+																	<widget class="GtkLabel" id="label21">
+																		<property name="label" translatable="yes">Directory</property>
+																		<property name="use_underline">False</property>
+																		<property name="use_markup">False</property>
+																		<property name="justify">GTK_JUSTIFY_CENTER</property>
+																		<property name="wrap">False</property>
+																		<property name="selectable">False</property>
+																		<property name="xalign">7.45058015283e-09</property>
+																		<property name="yalign">0.5</property>
+																		<property name="xpad">0</property>
+																		<property name="ypad">0</property>
+																		<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+																		<property name="width_chars">-1</property>
+																		<property name="single_line_mode">False</property>
+																		<property name="angle">0</property>
+																	</widget>
+																</child>
+															</widget>
+														</child>
+													</widget>
+													<packing>
+														<property name="padding">0</property>
+														<property name="expand">True</property>
+														<property name="fill">True</property>
+													</packing>
+												</child>
+											</widget>
+											<packing>
+												<property name="tab_expand">False</property>
+												<property name="tab_fill">True</property>
+											</packing>
+										</child>
 
-				  <child>
-				    <widget class="GtkLabel" id="label59">
-				      <property name="visible">True</property>
-				      <property name="label" translatable="yes">Select</property>
-				      <property name="use_underline">True</property>
-				      <property name="use_markup">False</property>
-				      <property name="justify">GTK_JUSTIFY_LEFT</property>
-				      <property name="wrap">False</property>
-				      <property name="selectable">False</property>
-				      <property name="xalign">0.5</property>
-				      <property name="yalign">0.5</property>
-				      <property name="xpad">0</property>
-				      <property name="ypad">0</property>
-				      <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-				      <property name="width_chars">-1</property>
-				      <property name="single_line_mode">False</property>
-				      <property name="angle">0</property>
-				    </widget>
-				    <packing>
-				      <property name="padding">0</property>
-				      <property name="expand">False</property>
-				      <property name="fill">False</property>
-				    </packing>
-				  </child>
-				</widget>
-			      </child>
-			    </widget>
-			  </child>
-			</widget>
-		      </child>
+										<child>
+											<widget class="GtkLabel" id="nl">
+												<property name="visible">True</property>
+												<property name="label" translatable="yes">Bad names</property>
+												<property name="use_underline">False</property>
+												<property name="use_markup">False</property>
+												<property name="justify">GTK_JUSTIFY_CENTER</property>
+												<property name="wrap">False</property>
+												<property name="selectable">False</property>
+												<property name="xalign">0.5</property>
+												<property name="yalign">0.5</property>
+												<property name="xpad">0</property>
+												<property name="ypad">0</property>
+												<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+												<property name="width_chars">-1</property>
+												<property name="single_line_mode">False</property>
+												<property name="angle">0</property>
+											</widget>
+											<packing>
+												<property name="type">tab</property>
+											</packing>
+										</child>
 
-		      <child>
-			<widget class="GtkButton" id="saveAs">
-			  <property name="visible">True</property>
-			  <property name="tooltip" translatable="yes">Save (selected) list to file</property>
-			  <property name="can_default">True</property>
-			  <property name="can_focus">True</property>
-			  <property name="relief">GTK_RELIEF_NORMAL</property>
-			  <property name="focus_on_click">True</property>
-			  <signal name="clicked" handler="on_saveAs_clicked"/>
+										<child>
+											<widget class="GtkVBox" id="vbox5">
+												<property name="visible">True</property>
+												<property name="homogeneous">False</property>
+												<property name="spacing">0</property>
 
-			  <child>
-			    <widget class="GtkAlignment" id="alignment6">
-			      <property name="visible">True</property>
-			      <property name="xalign">0.5</property>
-			      <property name="yalign">0.5</property>
-			      <property name="xscale">0</property>
-			      <property name="yscale">0</property>
-			      <property name="top_padding">0</property>
-			      <property name="bottom_padding">0</property>
-			      <property name="left_padding">0</property>
-			      <property name="right_padding">0</property>
+												<child>
+													<widget class="GtkHBox" id="hbox_sn">
+														<property name="visible">True</property>
+														<property name="homogeneous">False</property>
+														<property name="spacing">0</property>
 
-			      <child>
-				<widget class="GtkHBox" id="hbox14">
-				  <property name="visible">True</property>
-				  <property name="homogeneous">False</property>
-				  <property name="spacing">2</property>
+														<child>
+															<widget class="GtkLabel" id="label28">
+																<property name="visible">True</property>
+																<property name="label" translatable="yes">Search (</property>
+																<property name="use_underline">False</property>
+																<property name="use_markup">False</property>
+																<property name="justify">GTK_JUSTIFY_CENTER</property>
+																<property name="wrap">False</property>
+																<property name="selectable">False</property>
+																<property name="xalign">0.5</property>
+																<property name="yalign">0.5</property>
+																<property name="xpad">0</property>
+																<property name="ypad">0</property>
+																<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+																<property name="width_chars">-1</property>
+																<property name="single_line_mode">False</property>
+																<property name="angle">0</property>
+															</widget>
+															<packing>
+																<property name="padding">0</property>
+																<property name="expand">False</property>
+																<property name="fill">False</property>
+															</packing>
+														</child>
 
-				  <child>
-				    <widget class="GtkImage" id="image6">
-				      <property name="visible">True</property>
-				      <property name="stock">gtk-save-as</property>
-				      <property name="icon_size">4</property>
-				      <property name="xalign">0.5</property>
-				      <property name="yalign">0.5</property>
-				      <property name="xpad">0</property>
-				      <property name="ypad">0</property>
-				    </widget>
-				    <packing>
-				      <property name="padding">0</property>
-				      <property name="expand">False</property>
-				      <property name="fill">False</property>
-				    </packing>
-				  </child>
+														<child>
+															<widget class="GtkCheckButton" id="chk_sn_path">
+																<property name="visible">True</property>
+																<property name="can_focus">True</property>
+																<property name="label">$PATH</property>
+																<property name="use_underline">True</property>
+																<property name="relief">GTK_RELIEF_NORMAL</property>
+																<property name="focus_on_click">True</property>
+																<property name="active">True</property>
+																<property name="inconsistent">False</property>
+																<property name="draw_indicator">True</property>
+																<signal name="toggled" handler="on_chk_sn_path_toggled"/>
+															</widget>
+															<packing>
+																<property name="padding">0</property>
+																<property name="expand">False</property>
+																<property name="fill">False</property>
+															</packing>
+														</child>
 
-				  <child>
-				    <widget class="GtkLabel" id="label60">
-				      <property name="visible">True</property>
-				      <property name="label" translatable="yes">Save</property>
-				      <property name="use_underline">True</property>
-				      <property name="use_markup">False</property>
-				      <property name="justify">GTK_JUSTIFY_LEFT</property>
-				      <property name="wrap">False</property>
-				      <property name="selectable">False</property>
-				      <property name="xalign">0.5</property>
-				      <property name="yalign">0.5</property>
-				      <property name="xpad">0</property>
-				      <property name="ypad">0</property>
-				      <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-				      <property name="width_chars">-1</property>
-				      <property name="single_line_mode">False</property>
-				      <property name="angle">0</property>
-				    </widget>
-				    <packing>
-				      <property name="padding">0</property>
-				      <property name="expand">False</property>
-				      <property name="fill">False</property>
-				    </packing>
-				  </child>
-				</widget>
-			      </child>
-			    </widget>
-			  </child>
-			</widget>
-		      </child>
+														<child>
+															<widget class="GtkLabel" id="label27">
+																<property name="visible">True</property>
+																<property name="label" translatable="yes">) for</property>
+																<property name="use_underline">False</property>
+																<property name="use_markup">False</property>
+																<property name="justify">GTK_JUSTIFY_CENTER</property>
+																<property name="wrap">False</property>
+																<property name="selectable">False</property>
+																<property name="xalign">0.5</property>
+																<property name="yalign">0.5</property>
+																<property name="xpad">0</property>
+																<property name="ypad">0</property>
+																<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+																<property name="width_chars">-1</property>
+																<property name="single_line_mode">False</property>
+																<property name="angle">0</property>
+															</widget>
+															<packing>
+																<property name="padding">0</property>
+																<property name="expand">False</property>
+																<property name="fill">False</property>
+															</packing>
+														</child>
 
-		      <child>
-			<widget class="GtkButton" id="delSelected">
-			  <property name="visible">True</property>
-			  <property name="tooltip" translatable="yes">selected</property>
-			  <property name="can_default">True</property>
-			  <property name="can_focus">True</property>
-			  <property name="relief">GTK_RELIEF_NORMAL</property>
-			  <property name="focus_on_click">True</property>
-			  <signal name="clicked" handler="on_delSelected_clicked"/>
+														<child>
+															<widget class="GtkVBox" id="vbox6">
+																<property name="visible">True</property>
+																<property name="homogeneous">False</property>
+																<property name="spacing">0</property>
 
-			  <child>
-			    <widget class="GtkAlignment" id="alignment7">
-			      <property name="visible">True</property>
-			      <property name="xalign">0.5</property>
-			      <property name="yalign">0.5</property>
-			      <property name="xscale">0</property>
-			      <property name="yscale">0</property>
-			      <property name="top_padding">0</property>
-			      <property name="bottom_padding">0</property>
-			      <property name="left_padding">0</property>
-			      <property name="right_padding">0</property>
+																<child>
+																	<widget class="GtkHBox" id="hbox_sn_path">
+																		<property name="visible">True</property>
+																		<property name="homogeneous">False</property>
+																		<property name="spacing">0</property>
 
-			      <child>
-				<widget class="GtkHBox" id="hbox15">
-				  <property name="visible">True</property>
-				  <property name="homogeneous">False</property>
-				  <property name="spacing">2</property>
+																		<child>
+																			<widget class="GtkOptionMenu" id="opt_sn_path">
+																				<property name="visible">True</property>
+																				<property name="can_focus">True</property>
+																				<property name="history">0</property>
 
-				  <child>
-				    <widget class="GtkImage" id="image7">
-				      <property name="visible">True</property>
-				      <property name="stock">gtk-delete</property>
-				      <property name="icon_size">4</property>
-				      <property name="xalign">0.5</property>
-				      <property name="yalign">0.5</property>
-				      <property name="xpad">0</property>
-				      <property name="ypad">0</property>
-				    </widget>
-				    <packing>
-				      <property name="padding">0</property>
-				      <property name="expand">False</property>
-				      <property name="fill">False</property>
-				    </packing>
-				  </child>
+																				<child internal-child="menu">
+																					<widget class="GtkMenu" id="convertwidget9">
+																						<property name="visible">True</property>
 
-				  <child>
-				    <widget class="GtkLabel" id="label61">
-				      <property name="visible">True</property>
-				      <property name="label" translatable="yes">Delete</property>
-				      <property name="use_underline">True</property>
-				      <property name="use_markup">False</property>
-				      <property name="justify">GTK_JUSTIFY_LEFT</property>
-				      <property name="wrap">False</property>
-				      <property name="selectable">False</property>
-				      <property name="xalign">0.5</property>
-				      <property name="yalign">0.5</property>
-				      <property name="xpad">0</property>
-				      <property name="ypad">0</property>
-				      <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-				      <property name="width_chars">-1</property>
-				      <property name="single_line_mode">False</property>
-				      <property name="angle">0</property>
-				    </widget>
-				    <packing>
-				      <property name="padding">0</property>
-				      <property name="expand">False</property>
-				      <property name="fill">False</property>
-				    </packing>
-				  </child>
-				</widget>
-			      </child>
-			    </widget>
-			  </child>
-			</widget>
-		      </child>
+																						<child>
+																							<widget class="GtkMenuItem" id="convertwidget11">
+																								<property name="visible">True</property>
+																								<property name="label" translatable="yes">Conflicting files</property>
+																								<property name="use_underline">True</property>
+																							</widget>
+																						</child>
 
-		      <child>
-			<widget class="GtkButton" id="autoMerge">
-			  <property name="visible">True</property>
-			  <property name="tooltip" translatable="yes">All (except selected) using hardlinks
+																						<child>
+																							<widget class="GtkMenuItem" id="convertwidget10">
+																								<property name="visible">True</property>
+																								<property name="label" translatable="yes">Aliases</property>
+																								<property name="use_underline">True</property>
+																							</widget>
+																						</child>
+																					</widget>
+																				</child>
+																			</widget>
+																			<packing>
+																				<property name="padding">0</property>
+																				<property name="expand">False</property>
+																				<property name="fill">False</property>
+																			</packing>
+																		</child>
+																	</widget>
+																	<packing>
+																		<property name="padding">0</property>
+																		<property name="expand">True</property>
+																		<property name="fill">True</property>
+																	</packing>
+																</child>
+
+																<child>
+																	<widget class="GtkHBox" id="hbox_sn_paths">
+																		<property name="homogeneous">False</property>
+																		<property name="spacing">0</property>
+
+																		<child>
+																			<widget class="GtkOptionMenu" id="opt_sn_paths">
+																				<property name="visible">True</property>
+																				<property name="can_focus">True</property>
+																				<property name="history">0</property>
+
+																				<child internal-child="menu">
+																					<widget class="GtkMenu" id="convertwidget12">
+																						<property name="visible">True</property>
+
+																						<child>
+																							<widget class="GtkMenuItem" id="convertwidget16">
+																								<property name="visible">True</property>
+																								<property name="label" translatable="yes">Case conflicts</property>
+																								<property name="use_underline">True</property>
+																							</widget>
+																						</child>
+
+																						<child>
+																							<widget class="GtkMenuItem" id="convertwidget14">
+																								<property name="visible">True</property>
+																								<property name="label" translatable="yes">Same names</property>
+																								<property name="use_underline">True</property>
+																							</widget>
+																						</child>
+
+																						<child>
+																							<widget class="GtkMenuItem" id="convertwidget15">
+																								<property name="visible">True</property>
+																								<property name="label" translatable="yes">Same names(ignore case)</property>
+																								<property name="use_underline">True</property>
+																							</widget>
+																						</child>
+
+																						<child>
+																							<widget class="GtkMenuItem" id="convertwidget13">
+																								<property name="visible">True</property>
+																								<property name="label" translatable="yes">Aliases</property>
+																								<property name="use_underline">True</property>
+																							</widget>
+																						</child>
+																					</widget>
+																				</child>
+																			</widget>
+																			<packing>
+																				<property name="padding">0</property>
+																				<property name="expand">False</property>
+																				<property name="fill">False</property>
+																			</packing>
+																		</child>
+																	</widget>
+																	<packing>
+																		<property name="padding">0</property>
+																		<property name="expand">True</property>
+																		<property name="fill">True</property>
+																	</packing>
+																</child>
+															</widget>
+															<packing>
+																<property name="padding">0</property>
+																<property name="expand">True</property>
+																<property name="fill">True</property>
+															</packing>
+														</child>
+													</widget>
+													<packing>
+														<property name="padding">0</property>
+														<property name="expand">False</property>
+														<property name="fill">False</property>
+													</packing>
+												</child>
+
+												<child>
+													<widget class="GtkScrolledWindow" id="scrolledwindow6">
+														<property name="visible">True</property>
+														<property name="hscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
+														<property name="vscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
+														<property name="shadow_type">GTK_SHADOW_NONE</property>
+														<property name="window_placement">GTK_CORNER_TOP_LEFT</property>
+
+														<child>
+															<widget class="GtkCList" id="clist_sn">
+																<property name="border_width">1</property>
+																<property name="visible">True</property>
+																<property name="can_focus">True</property>
+																<property name="n_columns">3</property>
+																<property name="column_widths">80,80,80</property>
+																<property name="selection_mode">GTK_SELECTION_MULTIPLE</property>
+																<property name="show_titles">True</property>
+																<property name="shadow_type">GTK_SHADOW_IN</property>
+																<signal name="button_press_event" handler="on_selection_menu_button_press_event" last_modification_time="Mon, 18 Dec 2006 19:18:32 GMT"/>
+
+																<child>
+																	<widget class="GtkLabel" id="label24">
+																		<property name="label" translatable="yes">Name</property>
+																		<property name="use_underline">False</property>
+																		<property name="use_markup">False</property>
+																		<property name="justify">GTK_JUSTIFY_LEFT</property>
+																		<property name="wrap">False</property>
+																		<property name="selectable">False</property>
+																		<property name="xalign">7.45058015283e-09</property>
+																		<property name="yalign">0.5</property>
+																		<property name="xpad">0</property>
+																		<property name="ypad">0</property>
+																		<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+																		<property name="width_chars">-1</property>
+																		<property name="single_line_mode">False</property>
+																		<property name="angle">0</property>
+																	</widget>
+																</child>
+
+																<child>
+																	<widget class="GtkLabel" id="label25">
+																		<property name="label" translatable="yes">Directory</property>
+																		<property name="use_underline">False</property>
+																		<property name="use_markup">False</property>
+																		<property name="justify">GTK_JUSTIFY_LEFT</property>
+																		<property name="wrap">False</property>
+																		<property name="selectable">False</property>
+																		<property name="xalign">7.45058015283e-09</property>
+																		<property name="yalign">0.5</property>
+																		<property name="xpad">0</property>
+																		<property name="ypad">0</property>
+																		<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+																		<property name="width_chars">-1</property>
+																		<property name="single_line_mode">False</property>
+																		<property name="angle">0</property>
+																	</widget>
+																</child>
+
+																<child>
+																	<widget class="GtkLabel" id="label26">
+																		<property name="label" translatable="yes">Size</property>
+																		<property name="use_underline">False</property>
+																		<property name="use_markup">False</property>
+																		<property name="justify">GTK_JUSTIFY_RIGHT</property>
+																		<property name="wrap">False</property>
+																		<property name="selectable">False</property>
+																		<property name="xalign">7.45058015283e-09</property>
+																		<property name="yalign">0.5</property>
+																		<property name="xpad">0</property>
+																		<property name="ypad">0</property>
+																		<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+																		<property name="width_chars">-1</property>
+																		<property name="single_line_mode">False</property>
+																		<property name="angle">0</property>
+																	</widget>
+																</child>
+															</widget>
+														</child>
+													</widget>
+													<packing>
+														<property name="padding">0</property>
+														<property name="expand">True</property>
+														<property name="fill">True</property>
+													</packing>
+												</child>
+											</widget>
+											<packing>
+												<property name="tab_expand">False</property>
+												<property name="tab_fill">True</property>
+											</packing>
+										</child>
+
+										<child>
+											<widget class="GtkLabel" id="sn">
+												<property name="visible">True</property>
+												<property name="label" translatable="yes">Name clashes</property>
+												<property name="use_underline">False</property>
+												<property name="use_markup">False</property>
+												<property name="justify">GTK_JUSTIFY_CENTER</property>
+												<property name="wrap">False</property>
+												<property name="selectable">False</property>
+												<property name="xalign">0.5</property>
+												<property name="yalign">0.5</property>
+												<property name="xpad">0</property>
+												<property name="ypad">0</property>
+												<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+												<property name="width_chars">-1</property>
+												<property name="single_line_mode">False</property>
+												<property name="angle">0</property>
+											</widget>
+											<packing>
+												<property name="type">tab</property>
+											</packing>
+										</child>
+
+										<child>
+											<widget class="GtkVBox" id="vbox7">
+												<property name="visible">True</property>
+												<property name="homogeneous">False</property>
+												<property name="spacing">0</property>
+
+												<child>
+													<widget class="GtkHBox" id="hbox6">
+														<property name="visible">True</property>
+														<property name="homogeneous">False</property>
+														<property name="spacing">0</property>
+
+														<child>
+															<widget class="GtkCheckButton" id="chk_tf_core">
+																<property name="visible">True</property>
+																<property name="tooltip" translatable="yes">More restrictive search for core files</property>
+																<property name="can_focus">True</property>
+																<property name="label" translatable="yes">core file mode?</property>
+																<property name="use_underline">True</property>
+																<property name="relief">GTK_RELIEF_NORMAL</property>
+																<property name="focus_on_click">True</property>
+																<property name="active">False</property>
+																<property name="inconsistent">False</property>
+																<property name="draw_indicator">True</property>
+															</widget>
+															<packing>
+																<property name="padding">0</property>
+																<property name="expand">False</property>
+																<property name="fill">False</property>
+															</packing>
+														</child>
+
+														<child>
+															<widget class="GtkHBox" id="hbox7">
+																<property name="visible">True</property>
+																<property name="homogeneous">False</property>
+																<property name="spacing">0</property>
+
+																<child>
+																	<widget class="GtkSpinButton" id="spin_tf_core">
+																		<property name="visible">True</property>
+																		<property name="tooltip" translatable="yes">days</property>
+																		<property name="can_focus">True</property>
+																		<property name="climb_rate">1</property>
+																		<property name="digits">0</property>
+																		<property name="numeric">True</property>
+																		<property name="update_policy">GTK_UPDATE_ALWAYS</property>
+																		<property name="snap_to_ticks">False</property>
+																		<property name="wrap">False</property>
+																		<property name="adjustment">0 0 9999 1 7 0</property>
+																	</widget>
+																	<packing>
+																		<property name="padding">0</property>
+																		<property name="expand">False</property>
+																		<property name="fill">False</property>
+																	</packing>
+																</child>
+
+																<child>
+																	<widget class="GtkLabel" id="label33">
+																		<property name="visible">True</property>
+																		<property name="label" translatable="yes">minimum age</property>
+																		<property name="use_underline">False</property>
+																		<property name="use_markup">False</property>
+																		<property name="justify">GTK_JUSTIFY_CENTER</property>
+																		<property name="wrap">False</property>
+																		<property name="selectable">False</property>
+																		<property name="xalign">0.5</property>
+																		<property name="yalign">0.5</property>
+																		<property name="xpad">0</property>
+																		<property name="ypad">0</property>
+																		<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+																		<property name="width_chars">-1</property>
+																		<property name="single_line_mode">False</property>
+																		<property name="angle">0</property>
+																	</widget>
+																	<packing>
+																		<property name="padding">0</property>
+																		<property name="expand">False</property>
+																		<property name="fill">False</property>
+																	</packing>
+																</child>
+															</widget>
+															<packing>
+																<property name="padding">0</property>
+																<property name="expand">True</property>
+																<property name="fill">True</property>
+															</packing>
+														</child>
+													</widget>
+													<packing>
+														<property name="padding">0</property>
+														<property name="expand">False</property>
+														<property name="fill">False</property>
+													</packing>
+												</child>
+
+												<child>
+													<widget class="GtkScrolledWindow" id="scrolledwindow7">
+														<property name="visible">True</property>
+														<property name="hscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
+														<property name="vscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
+														<property name="shadow_type">GTK_SHADOW_NONE</property>
+														<property name="window_placement">GTK_CORNER_TOP_LEFT</property>
+
+														<child>
+															<widget class="GtkCList" id="clist_tf">
+																<property name="border_width">1</property>
+																<property name="visible">True</property>
+																<property name="can_focus">True</property>
+																<property name="n_columns">4</property>
+																<property name="column_widths">80,80,80,80</property>
+																<property name="selection_mode">GTK_SELECTION_MULTIPLE</property>
+																<property name="show_titles">True</property>
+																<property name="shadow_type">GTK_SHADOW_IN</property>
+																<signal name="button_press_event" handler="on_selection_menu_button_press_event" last_modification_time="Mon, 18 Dec 2006 19:18:52 GMT"/>
+
+																<child>
+																	<widget class="GtkLabel" id="label29">
+																		<property name="label" translatable="yes">Name</property>
+																		<property name="use_underline">False</property>
+																		<property name="use_markup">False</property>
+																		<property name="justify">GTK_JUSTIFY_CENTER</property>
+																		<property name="wrap">False</property>
+																		<property name="selectable">False</property>
+																		<property name="xalign">7.45058015283e-09</property>
+																		<property name="yalign">0.5</property>
+																		<property name="xpad">0</property>
+																		<property name="ypad">0</property>
+																		<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+																		<property name="width_chars">-1</property>
+																		<property name="single_line_mode">False</property>
+																		<property name="angle">0</property>
+																	</widget>
+																</child>
+
+																<child>
+																	<widget class="GtkLabel" id="label30">
+																		<property name="label" translatable="yes">Directory</property>
+																		<property name="use_underline">False</property>
+																		<property name="use_markup">False</property>
+																		<property name="justify">GTK_JUSTIFY_CENTER</property>
+																		<property name="wrap">False</property>
+																		<property name="selectable">False</property>
+																		<property name="xalign">7.45058015283e-09</property>
+																		<property name="yalign">0.5</property>
+																		<property name="xpad">0</property>
+																		<property name="ypad">0</property>
+																		<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+																		<property name="width_chars">-1</property>
+																		<property name="single_line_mode">False</property>
+																		<property name="angle">0</property>
+																	</widget>
+																</child>
+
+																<child>
+																	<widget class="GtkLabel" id="label31">
+																		<property name="label" translatable="yes">Size</property>
+																		<property name="use_underline">False</property>
+																		<property name="use_markup">False</property>
+																		<property name="justify">GTK_JUSTIFY_CENTER</property>
+																		<property name="wrap">False</property>
+																		<property name="selectable">False</property>
+																		<property name="xalign">7.45058015283e-09</property>
+																		<property name="yalign">0.5</property>
+																		<property name="xpad">0</property>
+																		<property name="ypad">0</property>
+																		<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+																		<property name="width_chars">-1</property>
+																		<property name="single_line_mode">False</property>
+																		<property name="angle">0</property>
+																	</widget>
+																</child>
+
+																<child>
+																	<widget class="GtkLabel" id="label32">
+																		<property name="label" translatable="yes">Date</property>
+																		<property name="use_underline">False</property>
+																		<property name="use_markup">False</property>
+																		<property name="justify">GTK_JUSTIFY_CENTER</property>
+																		<property name="wrap">False</property>
+																		<property name="selectable">False</property>
+																		<property name="xalign">7.45058015283e-09</property>
+																		<property name="yalign">0.5</property>
+																		<property name="xpad">0</property>
+																		<property name="ypad">0</property>
+																		<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+																		<property name="width_chars">-1</property>
+																		<property name="single_line_mode">False</property>
+																		<property name="angle">0</property>
+																	</widget>
+																</child>
+															</widget>
+														</child>
+													</widget>
+													<packing>
+														<property name="padding">0</property>
+														<property name="expand">True</property>
+														<property name="fill">True</property>
+													</packing>
+												</child>
+											</widget>
+											<packing>
+												<property name="tab_expand">False</property>
+												<property name="tab_fill">True</property>
+											</packing>
+										</child>
+
+										<child>
+											<widget class="GtkLabel" id="tf">
+												<property name="visible">True</property>
+												<property name="label" translatable="yes">Temp files</property>
+												<property name="use_underline">False</property>
+												<property name="use_markup">False</property>
+												<property name="justify">GTK_JUSTIFY_CENTER</property>
+												<property name="wrap">False</property>
+												<property name="selectable">False</property>
+												<property name="xalign">0.5</property>
+												<property name="yalign">0.5</property>
+												<property name="xpad">0</property>
+												<property name="ypad">0</property>
+												<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+												<property name="width_chars">-1</property>
+												<property name="single_line_mode">False</property>
+												<property name="angle">0</property>
+											</widget>
+											<packing>
+												<property name="type">tab</property>
+											</packing>
+										</child>
+
+										<child>
+											<widget class="GtkVBox" id="vbox8">
+												<property name="visible">True</property>
+												<property name="homogeneous">False</property>
+												<property name="spacing">0</property>
+
+												<child>
+													<widget class="GtkHBox" id="hbox8">
+														<property name="visible">True</property>
+														<property name="homogeneous">False</property>
+														<property name="spacing">0</property>
+
+														<child>
+															<widget class="GtkRadioButton" id="opt_bl_dangling">
+																<property name="visible">True</property>
+																<property name="can_focus">True</property>
+																<property name="label" translatable="yes">Dangling</property>
+																<property name="use_underline">True</property>
+																<property name="relief">GTK_RELIEF_NORMAL</property>
+																<property name="focus_on_click">True</property>
+																<property name="active">True</property>
+																<property name="inconsistent">False</property>
+																<property name="draw_indicator">True</property>
+															</widget>
+															<packing>
+																<property name="padding">0</property>
+																<property name="expand">False</property>
+																<property name="fill">False</property>
+															</packing>
+														</child>
+
+														<child>
+															<widget class="GtkRadioButton" id="opt_bl_suspect">
+																<property name="visible">True</property>
+																<property name="tooltip" translatable="yes">Absolute links to paths within or below the link's directory</property>
+																<property name="can_focus">True</property>
+																<property name="label" translatable="yes">Suspect</property>
+																<property name="use_underline">True</property>
+																<property name="relief">GTK_RELIEF_NORMAL</property>
+																<property name="focus_on_click">True</property>
+																<property name="active">False</property>
+																<property name="inconsistent">False</property>
+																<property name="draw_indicator">True</property>
+																<property name="group">opt_bl_dangling</property>
+															</widget>
+															<packing>
+																<property name="padding">0</property>
+																<property name="expand">False</property>
+																<property name="fill">False</property>
+															</packing>
+														</child>
+
+														<child>
+															<widget class="GtkRadioButton" id="opt_bl_relative">
+																<property name="visible">True</property>
+																<property name="can_focus">True</property>
+																<property name="label" translatable="yes">Relative</property>
+																<property name="use_underline">True</property>
+																<property name="relief">GTK_RELIEF_NORMAL</property>
+																<property name="focus_on_click">True</property>
+																<property name="active">False</property>
+																<property name="inconsistent">False</property>
+																<property name="draw_indicator">True</property>
+																<property name="group">opt_bl_dangling</property>
+															</widget>
+															<packing>
+																<property name="padding">0</property>
+																<property name="expand">False</property>
+																<property name="fill">False</property>
+															</packing>
+														</child>
+
+														<child>
+															<widget class="GtkRadioButton" id="opt_bl_absolute">
+																<property name="visible">True</property>
+																<property name="can_focus">True</property>
+																<property name="label" translatable="yes">Absolute</property>
+																<property name="use_underline">True</property>
+																<property name="relief">GTK_RELIEF_NORMAL</property>
+																<property name="focus_on_click">True</property>
+																<property name="active">False</property>
+																<property name="inconsistent">False</property>
+																<property name="draw_indicator">True</property>
+																<property name="group">opt_bl_dangling</property>
+															</widget>
+															<packing>
+																<property name="padding">0</property>
+																<property name="expand">False</property>
+																<property name="fill">False</property>
+															</packing>
+														</child>
+
+														<child>
+															<widget class="GtkRadioButton" id="opt_bl_redundant">
+																<property name="visible">True</property>
+																<property name="tooltip" translatable="yes">/././. ///// /../ etc.</property>
+																<property name="can_focus">True</property>
+																<property name="label" translatable="yes">Redundant naming</property>
+																<property name="use_underline">True</property>
+																<property name="relief">GTK_RELIEF_NORMAL</property>
+																<property name="focus_on_click">True</property>
+																<property name="active">False</property>
+																<property name="inconsistent">False</property>
+																<property name="draw_indicator">True</property>
+																<property name="group">opt_bl_dangling</property>
+															</widget>
+															<packing>
+																<property name="padding">0</property>
+																<property name="expand">False</property>
+																<property name="fill">False</property>
+															</packing>
+														</child>
+													</widget>
+													<packing>
+														<property name="padding">0</property>
+														<property name="expand">False</property>
+														<property name="fill">False</property>
+													</packing>
+												</child>
+
+												<child>
+													<widget class="GtkScrolledWindow" id="scrolledwindow8">
+														<property name="visible">True</property>
+														<property name="hscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
+														<property name="vscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
+														<property name="shadow_type">GTK_SHADOW_NONE</property>
+														<property name="window_placement">GTK_CORNER_TOP_LEFT</property>
+
+														<child>
+															<widget class="GtkCList" id="clist_bl">
+																<property name="border_width">1</property>
+																<property name="visible">True</property>
+																<property name="can_focus">True</property>
+																<property name="n_columns">3</property>
+																<property name="column_widths">80,80,80</property>
+																<property name="selection_mode">GTK_SELECTION_MULTIPLE</property>
+																<property name="show_titles">True</property>
+																<property name="shadow_type">GTK_SHADOW_IN</property>
+																<signal name="button_press_event" handler="on_selection_menu_button_press_event" last_modification_time="Mon, 18 Dec 2006 19:19:04 GMT"/>
+
+																<child>
+																	<widget class="GtkLabel" id="label34">
+																		<property name="label" translatable="yes">Name</property>
+																		<property name="use_underline">False</property>
+																		<property name="use_markup">False</property>
+																		<property name="justify">GTK_JUSTIFY_CENTER</property>
+																		<property name="wrap">False</property>
+																		<property name="selectable">False</property>
+																		<property name="xalign">7.45058015283e-09</property>
+																		<property name="yalign">0.5</property>
+																		<property name="xpad">0</property>
+																		<property name="ypad">0</property>
+																		<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+																		<property name="width_chars">-1</property>
+																		<property name="single_line_mode">False</property>
+																		<property name="angle">0</property>
+																	</widget>
+																</child>
+
+																<child>
+																	<widget class="GtkLabel" id="label35">
+																		<property name="label" translatable="yes">Directory</property>
+																		<property name="use_underline">False</property>
+																		<property name="use_markup">False</property>
+																		<property name="justify">GTK_JUSTIFY_CENTER</property>
+																		<property name="wrap">False</property>
+																		<property name="selectable">False</property>
+																		<property name="xalign">7.45058015283e-09</property>
+																		<property name="yalign">0.5</property>
+																		<property name="xpad">0</property>
+																		<property name="ypad">0</property>
+																		<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+																		<property name="width_chars">-1</property>
+																		<property name="single_line_mode">False</property>
+																		<property name="angle">0</property>
+																	</widget>
+																</child>
+
+																<child>
+																	<widget class="GtkLabel" id="label36">
+																		<property name="label" translatable="yes">Target</property>
+																		<property name="use_underline">False</property>
+																		<property name="use_markup">False</property>
+																		<property name="justify">GTK_JUSTIFY_CENTER</property>
+																		<property name="wrap">False</property>
+																		<property name="selectable">False</property>
+																		<property name="xalign">7.45058015283e-09</property>
+																		<property name="yalign">0.5</property>
+																		<property name="xpad">0</property>
+																		<property name="ypad">0</property>
+																		<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+																		<property name="width_chars">-1</property>
+																		<property name="single_line_mode">False</property>
+																		<property name="angle">0</property>
+																	</widget>
+																</child>
+															</widget>
+														</child>
+													</widget>
+													<packing>
+														<property name="padding">0</property>
+														<property name="expand">True</property>
+														<property name="fill">True</property>
+													</packing>
+												</child>
+											</widget>
+											<packing>
+												<property name="tab_expand">False</property>
+												<property name="tab_fill">True</property>
+											</packing>
+										</child>
+
+										<child>
+											<widget class="GtkLabel" id="bl">
+												<property name="visible">True</property>
+												<property name="label" translatable="yes">Bad symlinks</property>
+												<property name="use_underline">False</property>
+												<property name="use_markup">False</property>
+												<property name="justify">GTK_JUSTIFY_CENTER</property>
+												<property name="wrap">False</property>
+												<property name="selectable">False</property>
+												<property name="xalign">0.5</property>
+												<property name="yalign">0.5</property>
+												<property name="xpad">0</property>
+												<property name="ypad">0</property>
+												<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+												<property name="width_chars">-1</property>
+												<property name="single_line_mode">False</property>
+												<property name="angle">0</property>
+											</widget>
+											<packing>
+												<property name="type">tab</property>
+											</packing>
+										</child>
+
+										<child>
+											<widget class="GtkVBox" id="vbox2">
+												<property name="visible">True</property>
+												<property name="homogeneous">False</property>
+												<property name="spacing">0</property>
+
+												<child>
+													<widget class="GtkScrolledWindow" id="scrolledwindow9">
+														<property name="visible">True</property>
+														<property name="hscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
+														<property name="vscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
+														<property name="shadow_type">GTK_SHADOW_NONE</property>
+														<property name="window_placement">GTK_CORNER_TOP_LEFT</property>
+
+														<child>
+															<widget class="GtkCList" id="clist_id">
+																<property name="border_width">1</property>
+																<property name="visible">True</property>
+																<property name="can_focus">True</property>
+																<property name="n_columns">6</property>
+																<property name="column_widths">80,80,41,47,80,80</property>
+																<property name="selection_mode">GTK_SELECTION_MULTIPLE</property>
+																<property name="show_titles">True</property>
+																<property name="shadow_type">GTK_SHADOW_IN</property>
+																<signal name="button_press_event" handler="on_selection_menu_button_press_event" last_modification_time="Mon, 18 Dec 2006 19:19:19 GMT"/>
+
+																<child>
+																	<widget class="GtkLabel" id="label37">
+																		<property name="label" translatable="yes">Name</property>
+																		<property name="use_underline">False</property>
+																		<property name="use_markup">False</property>
+																		<property name="justify">GTK_JUSTIFY_CENTER</property>
+																		<property name="wrap">False</property>
+																		<property name="selectable">False</property>
+																		<property name="xalign">1.22935006175e-07</property>
+																		<property name="yalign">0.5</property>
+																		<property name="xpad">0</property>
+																		<property name="ypad">0</property>
+																		<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+																		<property name="width_chars">-1</property>
+																		<property name="single_line_mode">False</property>
+																		<property name="angle">0</property>
+																	</widget>
+																</child>
+
+																<child>
+																	<widget class="GtkLabel" id="label38">
+																		<property name="label" translatable="yes">Directory</property>
+																		<property name="use_underline">False</property>
+																		<property name="use_markup">False</property>
+																		<property name="justify">GTK_JUSTIFY_CENTER</property>
+																		<property name="wrap">False</property>
+																		<property name="selectable">False</property>
+																		<property name="xalign">7.45058015283e-09</property>
+																		<property name="yalign">0.5</property>
+																		<property name="xpad">0</property>
+																		<property name="ypad">0</property>
+																		<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+																		<property name="width_chars">-1</property>
+																		<property name="single_line_mode">False</property>
+																		<property name="angle">0</property>
+																	</widget>
+																</child>
+
+																<child>
+																	<widget class="GtkLabel" id="label39">
+																		<property name="label" translatable="yes">UID</property>
+																		<property name="use_underline">False</property>
+																		<property name="use_markup">False</property>
+																		<property name="justify">GTK_JUSTIFY_CENTER</property>
+																		<property name="wrap">False</property>
+																		<property name="selectable">False</property>
+																		<property name="xalign">7.45058015283e-09</property>
+																		<property name="yalign">0.5</property>
+																		<property name="xpad">0</property>
+																		<property name="ypad">0</property>
+																		<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+																		<property name="width_chars">-1</property>
+																		<property name="single_line_mode">False</property>
+																		<property name="angle">0</property>
+																	</widget>
+																</child>
+
+																<child>
+																	<widget class="GtkLabel" id="label40">
+																		<property name="label" translatable="yes">GID</property>
+																		<property name="use_underline">False</property>
+																		<property name="use_markup">False</property>
+																		<property name="justify">GTK_JUSTIFY_CENTER</property>
+																		<property name="wrap">False</property>
+																		<property name="selectable">False</property>
+																		<property name="xalign">7.45058015283e-09</property>
+																		<property name="yalign">0.5</property>
+																		<property name="xpad">0</property>
+																		<property name="ypad">0</property>
+																		<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+																		<property name="width_chars">-1</property>
+																		<property name="single_line_mode">False</property>
+																		<property name="angle">0</property>
+																	</widget>
+																</child>
+
+																<child>
+																	<widget class="GtkLabel" id="label41">
+																		<property name="label" translatable="yes">Size</property>
+																		<property name="use_underline">False</property>
+																		<property name="use_markup">False</property>
+																		<property name="justify">GTK_JUSTIFY_CENTER</property>
+																		<property name="wrap">False</property>
+																		<property name="selectable">False</property>
+																		<property name="xalign">7.45058015283e-09</property>
+																		<property name="yalign">0.5</property>
+																		<property name="xpad">0</property>
+																		<property name="ypad">0</property>
+																		<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+																		<property name="width_chars">-1</property>
+																		<property name="single_line_mode">False</property>
+																		<property name="angle">0</property>
+																	</widget>
+																</child>
+
+																<child>
+																	<widget class="GtkLabel" id="label42">
+																		<property name="label" translatable="yes">Date</property>
+																		<property name="use_underline">False</property>
+																		<property name="use_markup">False</property>
+																		<property name="justify">GTK_JUSTIFY_CENTER</property>
+																		<property name="wrap">False</property>
+																		<property name="selectable">False</property>
+																		<property name="xalign">7.45058015283e-09</property>
+																		<property name="yalign">0.5</property>
+																		<property name="xpad">0</property>
+																		<property name="ypad">0</property>
+																		<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+																		<property name="width_chars">-1</property>
+																		<property name="single_line_mode">False</property>
+																		<property name="angle">0</property>
+																	</widget>
+																</child>
+															</widget>
+														</child>
+													</widget>
+													<packing>
+														<property name="padding">0</property>
+														<property name="expand">True</property>
+														<property name="fill">True</property>
+													</packing>
+												</child>
+											</widget>
+											<packing>
+												<property name="tab_expand">False</property>
+												<property name="tab_fill">True</property>
+											</packing>
+										</child>
+
+										<child>
+											<widget class="GtkLabel" id="id">
+												<property name="visible">True</property>
+												<property name="label" translatable="yes">Bad IDs</property>
+												<property name="use_underline">False</property>
+												<property name="use_markup">False</property>
+												<property name="justify">GTK_JUSTIFY_CENTER</property>
+												<property name="wrap">False</property>
+												<property name="selectable">False</property>
+												<property name="xalign">0.5</property>
+												<property name="yalign">0.5</property>
+												<property name="xpad">0</property>
+												<property name="ypad">0</property>
+												<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+												<property name="width_chars">-1</property>
+												<property name="single_line_mode">False</property>
+												<property name="angle">0</property>
+											</widget>
+											<packing>
+												<property name="type">tab</property>
+											</packing>
+										</child>
+
+										<child>
+											<widget class="GtkScrolledWindow" id="scrolledwindow10">
+												<property name="visible">True</property>
+												<property name="hscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
+												<property name="vscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
+												<property name="shadow_type">GTK_SHADOW_NONE</property>
+												<property name="window_placement">GTK_CORNER_TOP_LEFT</property>
+
+												<child>
+													<widget class="GtkCList" id="clist_ed">
+														<property name="border_width">1</property>
+														<property name="visible">True</property>
+														<property name="can_focus">True</property>
+														<property name="n_columns">3</property>
+														<property name="column_widths">80,80,80</property>
+														<property name="selection_mode">GTK_SELECTION_MULTIPLE</property>
+														<property name="show_titles">True</property>
+														<property name="shadow_type">GTK_SHADOW_IN</property>
+														<signal name="button_press_event" handler="on_selection_menu_button_press_event" last_modification_time="Mon, 18 Dec 2006 19:19:32 GMT"/>
+
+														<child>
+															<widget class="GtkLabel" id="label43">
+																<property name="label" translatable="yes">Name</property>
+																<property name="use_underline">False</property>
+																<property name="use_markup">False</property>
+																<property name="justify">GTK_JUSTIFY_CENTER</property>
+																<property name="wrap">False</property>
+																<property name="selectable">False</property>
+																<property name="xalign">7.45058015283e-09</property>
+																<property name="yalign">0.5</property>
+																<property name="xpad">0</property>
+																<property name="ypad">0</property>
+																<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+																<property name="width_chars">-1</property>
+																<property name="single_line_mode">False</property>
+																<property name="angle">0</property>
+															</widget>
+														</child>
+
+														<child>
+															<widget class="GtkLabel" id="label53">
+																<property name="label" translatable="yes">Directory</property>
+																<property name="use_underline">False</property>
+																<property name="use_markup">False</property>
+																<property name="justify">GTK_JUSTIFY_CENTER</property>
+																<property name="wrap">False</property>
+																<property name="selectable">False</property>
+																<property name="xalign">7.45058015283e-09</property>
+																<property name="yalign">0.5</property>
+																<property name="xpad">0</property>
+																<property name="ypad">0</property>
+																<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+																<property name="width_chars">-1</property>
+																<property name="single_line_mode">False</property>
+																<property name="angle">0</property>
+															</widget>
+														</child>
+
+														<child>
+															<widget class="GtkLabel" id="label44">
+																<property name="label" translatable="yes">Date</property>
+																<property name="use_underline">False</property>
+																<property name="use_markup">False</property>
+																<property name="justify">GTK_JUSTIFY_CENTER</property>
+																<property name="wrap">False</property>
+																<property name="selectable">False</property>
+																<property name="xalign">7.45058015283e-09</property>
+																<property name="yalign">0.5</property>
+																<property name="xpad">0</property>
+																<property name="ypad">0</property>
+																<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+																<property name="width_chars">-1</property>
+																<property name="single_line_mode">False</property>
+																<property name="angle">0</property>
+															</widget>
+														</child>
+													</widget>
+												</child>
+											</widget>
+											<packing>
+												<property name="tab_expand">False</property>
+												<property name="tab_fill">True</property>
+											</packing>
+										</child>
+
+										<child>
+											<widget class="GtkLabel" id="ed">
+												<property name="visible">True</property>
+												<property name="label" translatable="yes">Empty directories</property>
+												<property name="use_underline">False</property>
+												<property name="use_markup">False</property>
+												<property name="justify">GTK_JUSTIFY_CENTER</property>
+												<property name="wrap">False</property>
+												<property name="selectable">False</property>
+												<property name="xalign">0.5</property>
+												<property name="yalign">0.5</property>
+												<property name="xpad">0</property>
+												<property name="ypad">0</property>
+												<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+												<property name="width_chars">-1</property>
+												<property name="single_line_mode">False</property>
+												<property name="angle">0</property>
+											</widget>
+											<packing>
+												<property name="type">tab</property>
+											</packing>
+										</child>
+
+										<child>
+											<widget class="GtkVBox" id="vbox9">
+												<property name="visible">True</property>
+												<property name="homogeneous">False</property>
+												<property name="spacing">0</property>
+
+												<child>
+													<widget class="GtkCheckButton" id="chk_ns_path">
+														<property name="visible">True</property>
+														<property name="can_focus">True</property>
+														<property name="label" translatable="yes">Search $PATH</property>
+														<property name="use_underline">True</property>
+														<property name="relief">GTK_RELIEF_NORMAL</property>
+														<property name="focus_on_click">True</property>
+														<property name="active">True</property>
+														<property name="inconsistent">False</property>
+														<property name="draw_indicator">True</property>
+													</widget>
+													<packing>
+														<property name="padding">0</property>
+														<property name="expand">False</property>
+														<property name="fill">False</property>
+													</packing>
+												</child>
+
+												<child>
+													<widget class="GtkScrolledWindow" id="scrolledwindow11">
+														<property name="visible">True</property>
+														<property name="hscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
+														<property name="vscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
+														<property name="shadow_type">GTK_SHADOW_NONE</property>
+														<property name="window_placement">GTK_CORNER_TOP_LEFT</property>
+
+														<child>
+															<widget class="GtkCList" id="clist_ns">
+																<property name="border_width">1</property>
+																<property name="visible">True</property>
+																<property name="can_focus">True</property>
+																<property name="n_columns">4</property>
+																<property name="column_widths">80,80,80,80</property>
+																<property name="selection_mode">GTK_SELECTION_MULTIPLE</property>
+																<property name="show_titles">True</property>
+																<property name="shadow_type">GTK_SHADOW_IN</property>
+																<signal name="button_press_event" handler="on_selection_menu_button_press_event" last_modification_time="Mon, 18 Dec 2006 19:19:47 GMT"/>
+
+																<child>
+																	<widget class="GtkLabel" id="label45">
+																		<property name="label" translatable="yes">Name</property>
+																		<property name="use_underline">False</property>
+																		<property name="use_markup">False</property>
+																		<property name="justify">GTK_JUSTIFY_CENTER</property>
+																		<property name="wrap">False</property>
+																		<property name="selectable">False</property>
+																		<property name="xalign">0</property>
+																		<property name="yalign">0.5</property>
+																		<property name="xpad">0</property>
+																		<property name="ypad">0</property>
+																		<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+																		<property name="width_chars">-1</property>
+																		<property name="single_line_mode">False</property>
+																		<property name="angle">0</property>
+																	</widget>
+																</child>
+
+																<child>
+																	<widget class="GtkLabel" id="label46">
+																		<property name="label" translatable="yes">Directory</property>
+																		<property name="use_underline">False</property>
+																		<property name="use_markup">False</property>
+																		<property name="justify">GTK_JUSTIFY_CENTER</property>
+																		<property name="wrap">False</property>
+																		<property name="selectable">False</property>
+																		<property name="xalign">7.45058015283e-09</property>
+																		<property name="yalign">0.5</property>
+																		<property name="xpad">0</property>
+																		<property name="ypad">0</property>
+																		<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+																		<property name="width_chars">-1</property>
+																		<property name="single_line_mode">False</property>
+																		<property name="angle">0</property>
+																	</widget>
+																</child>
+
+																<child>
+																	<widget class="GtkLabel" id="label47">
+																		<property name="label" translatable="yes">Size</property>
+																		<property name="use_underline">False</property>
+																		<property name="use_markup">False</property>
+																		<property name="justify">GTK_JUSTIFY_CENTER</property>
+																		<property name="wrap">False</property>
+																		<property name="selectable">False</property>
+																		<property name="xalign">7.45058015283e-09</property>
+																		<property name="yalign">0.5</property>
+																		<property name="xpad">0</property>
+																		<property name="ypad">0</property>
+																		<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+																		<property name="width_chars">-1</property>
+																		<property name="single_line_mode">False</property>
+																		<property name="angle">0</property>
+																	</widget>
+																</child>
+
+																<child>
+																	<widget class="GtkLabel" id="label52">
+																		<property name="label" translatable="yes">Date</property>
+																		<property name="use_underline">False</property>
+																		<property name="use_markup">False</property>
+																		<property name="justify">GTK_JUSTIFY_CENTER</property>
+																		<property name="wrap">False</property>
+																		<property name="selectable">False</property>
+																		<property name="xalign">7.45058015283e-09</property>
+																		<property name="yalign">0.5</property>
+																		<property name="xpad">0</property>
+																		<property name="ypad">0</property>
+																		<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+																		<property name="width_chars">-1</property>
+																		<property name="single_line_mode">False</property>
+																		<property name="angle">0</property>
+																	</widget>
+																</child>
+															</widget>
+														</child>
+													</widget>
+													<packing>
+														<property name="padding">0</property>
+														<property name="expand">True</property>
+														<property name="fill">True</property>
+													</packing>
+												</child>
+											</widget>
+											<packing>
+												<property name="tab_expand">False</property>
+												<property name="tab_fill">True</property>
+											</packing>
+										</child>
+
+										<child>
+											<widget class="GtkLabel" id="ns">
+												<property name="visible">True</property>
+												<property name="label" translatable="yes">Non stripped binaries</property>
+												<property name="use_underline">False</property>
+												<property name="use_markup">False</property>
+												<property name="justify">GTK_JUSTIFY_CENTER</property>
+												<property name="wrap">False</property>
+												<property name="selectable">False</property>
+												<property name="xalign">0.5</property>
+												<property name="yalign">0.5</property>
+												<property name="xpad">0</property>
+												<property name="ypad">0</property>
+												<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+												<property name="width_chars">-1</property>
+												<property name="single_line_mode">False</property>
+												<property name="angle">0</property>
+											</widget>
+											<packing>
+												<property name="type">tab</property>
+											</packing>
+										</child>
+
+										<child>
+											<widget class="GtkVBox" id="vbox10">
+												<property name="visible">True</property>
+												<property name="homogeneous">False</property>
+												<property name="spacing">0</property>
+
+												<child>
+													<widget class="GtkHBox" id="hbox24">
+														<property name="visible">True</property>
+														<property name="homogeneous">False</property>
+														<property name="spacing">2</property>
+
+														<child>
+															<widget class="GtkHBox" id="hbox25">
+																<property name="visible">True</property>
+																<property name="homogeneous">False</property>
+																<property name="spacing">0</property>
+
+																<child>
+																	<widget class="GtkCheckButton" id="chkTabs">
+																		<property name="visible">True</property>
+																		<property name="can_focus">True</property>
+																		<property name="relief">GTK_RELIEF_NORMAL</property>
+																		<property name="focus_on_click">True</property>
+																		<property name="active">False</property>
+																		<property name="inconsistent">False</property>
+																		<property name="draw_indicator">True</property>
+
+																		<child>
+																			<widget class="GtkAlignment" id="alignment15">
+																				<property name="visible">True</property>
+																				<property name="xalign">0.5</property>
+																				<property name="yalign">0.5</property>
+																				<property name="xscale">0</property>
+																				<property name="yscale">0</property>
+																				<property name="top_padding">0</property>
+																				<property name="bottom_padding">0</property>
+																				<property name="left_padding">0</property>
+																				<property name="right_padding">0</property>
+
+																				<child>
+																					<widget class="GtkHBox" id="hbox27">
+																						<property name="visible">True</property>
+																						<property name="homogeneous">False</property>
+																						<property name="spacing">2</property>
+
+																						<child>
+																							<widget class="GtkImage" id="image14">
+																								<property name="visible">True</property>
+																								<property name="stock">gtk-indent</property>
+																								<property name="icon_size">4</property>
+																								<property name="xalign">0.5</property>
+																								<property name="yalign">0.5</property>
+																								<property name="xpad">0</property>
+																								<property name="ypad">0</property>
+																							</widget>
+																							<packing>
+																								<property name="padding">0</property>
+																								<property name="expand">False</property>
+																								<property name="fill">False</property>
+																							</packing>
+																						</child>
+
+																						<child>
+																							<widget class="GtkLabel" id="label73">
+																								<property name="visible">True</property>
+																								<property name="label" translatable="yes">bad indenting for indent width</property>
+																								<property name="use_underline">True</property>
+																								<property name="use_markup">False</property>
+																								<property name="justify">GTK_JUSTIFY_LEFT</property>
+																								<property name="wrap">False</property>
+																								<property name="selectable">False</property>
+																								<property name="xalign">0.5</property>
+																								<property name="yalign">0.5</property>
+																								<property name="xpad">0</property>
+																								<property name="ypad">0</property>
+																								<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+																								<property name="width_chars">-1</property>
+																								<property name="single_line_mode">False</property>
+																								<property name="angle">0</property>
+																							</widget>
+																							<packing>
+																								<property name="padding">0</property>
+																								<property name="expand">False</property>
+																								<property name="fill">False</property>
+																							</packing>
+																						</child>
+																					</widget>
+																				</child>
+																			</widget>
+																		</child>
+																	</widget>
+																	<packing>
+																		<property name="padding">0</property>
+																		<property name="expand">False</property>
+																		<property name="fill">False</property>
+																	</packing>
+																</child>
+
+																<child>
+																	<widget class="GtkSpinButton" id="spinTabs">
+																		<property name="visible">True</property>
+																		<property name="can_focus">True</property>
+																		<property name="climb_rate">1</property>
+																		<property name="digits">0</property>
+																		<property name="numeric">True</property>
+																		<property name="update_policy">GTK_UPDATE_ALWAYS</property>
+																		<property name="snap_to_ticks">False</property>
+																		<property name="wrap">False</property>
+																		<property name="adjustment">8 2 16 1 4 0</property>
+																	</widget>
+																	<packing>
+																		<property name="padding">0</property>
+																		<property name="expand">False</property>
+																		<property name="fill">False</property>
+																		<property name="pack_type">GTK_PACK_END</property>
+																	</packing>
+																</child>
+															</widget>
+															<packing>
+																<property name="padding">0</property>
+																<property name="expand">False</property>
+																<property name="fill">False</property>
+															</packing>
+														</child>
+
+														<child>
+															<widget class="GtkCheckButton" id="chkWhitespace">
+																<property name="visible">True</property>
+																<property name="can_focus">True</property>
+																<property name="relief">GTK_RELIEF_NORMAL</property>
+																<property name="focus_on_click">True</property>
+																<property name="active">True</property>
+																<property name="inconsistent">False</property>
+																<property name="draw_indicator">True</property>
+
+																<child>
+																	<widget class="GtkAlignment" id="alignment14">
+																		<property name="visible">True</property>
+																		<property name="xalign">0.5</property>
+																		<property name="yalign">0.5</property>
+																		<property name="xscale">0</property>
+																		<property name="yscale">0</property>
+																		<property name="top_padding">0</property>
+																		<property name="bottom_padding">0</property>
+																		<property name="left_padding">0</property>
+																		<property name="right_padding">0</property>
+
+																		<child>
+																			<widget class="GtkHBox" id="hbox26">
+																				<property name="visible">True</property>
+																				<property name="homogeneous">False</property>
+																				<property name="spacing">2</property>
+
+																				<child>
+																					<widget class="GtkImage" id="image13">
+																						<property name="visible">True</property>
+																						<property name="stock">gtk-unindent</property>
+																						<property name="icon_size">4</property>
+																						<property name="xalign">0.5</property>
+																						<property name="yalign">0.5</property>
+																						<property name="xpad">0</property>
+																						<property name="ypad">0</property>
+																					</widget>
+																					<packing>
+																						<property name="padding">0</property>
+																						<property name="expand">False</property>
+																						<property name="fill">False</property>
+																					</packing>
+																				</child>
+
+																				<child>
+																					<widget class="GtkLabel" id="label72">
+																						<property name="visible">True</property>
+																						<property name="label" translatable="yes">whitespace at end of line</property>
+																						<property name="use_underline">True</property>
+																						<property name="use_markup">False</property>
+																						<property name="justify">GTK_JUSTIFY_LEFT</property>
+																						<property name="wrap">False</property>
+																						<property name="selectable">False</property>
+																						<property name="xalign">0.5</property>
+																						<property name="yalign">0.5</property>
+																						<property name="xpad">0</property>
+																						<property name="ypad">0</property>
+																						<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+																						<property name="width_chars">-1</property>
+																						<property name="single_line_mode">False</property>
+																						<property name="angle">0</property>
+																					</widget>
+																					<packing>
+																						<property name="padding">0</property>
+																						<property name="expand">False</property>
+																						<property name="fill">False</property>
+																					</packing>
+																				</child>
+																			</widget>
+																		</child>
+																	</widget>
+																</child>
+															</widget>
+															<packing>
+																<property name="padding">0</property>
+																<property name="expand">False</property>
+																<property name="fill">False</property>
+																<property name="pack_type">GTK_PACK_END</property>
+															</packing>
+														</child>
+													</widget>
+													<packing>
+														<property name="padding">0</property>
+														<property name="expand">False</property>
+														<property name="fill">True</property>
+													</packing>
+												</child>
+
+												<child>
+													<widget class="GtkScrolledWindow" id="scrolledwindow12">
+														<property name="visible">True</property>
+														<property name="hscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
+														<property name="vscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
+														<property name="shadow_type">GTK_SHADOW_NONE</property>
+														<property name="window_placement">GTK_CORNER_TOP_LEFT</property>
+
+														<child>
+															<widget class="GtkCList" id="clist_rs">
+																<property name="border_width">1</property>
+																<property name="visible">True</property>
+																<property name="can_focus">True</property>
+																<property name="n_columns">4</property>
+																<property name="column_widths">80,80,80,80</property>
+																<property name="selection_mode">GTK_SELECTION_MULTIPLE</property>
+																<property name="show_titles">True</property>
+																<property name="shadow_type">GTK_SHADOW_IN</property>
+																<signal name="button_press_event" handler="on_selection_menu_button_press_event" last_modification_time="Mon, 18 Dec 2006 19:20:00 GMT"/>
+
+																<child>
+																	<widget class="GtkLabel" id="label48">
+																		<property name="label" translatable="yes">Name</property>
+																		<property name="use_underline">False</property>
+																		<property name="use_markup">False</property>
+																		<property name="justify">GTK_JUSTIFY_CENTER</property>
+																		<property name="wrap">False</property>
+																		<property name="selectable">False</property>
+																		<property name="xalign">7.45058015283e-09</property>
+																		<property name="yalign">0.5</property>
+																		<property name="xpad">0</property>
+																		<property name="ypad">0</property>
+																		<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+																		<property name="width_chars">-1</property>
+																		<property name="single_line_mode">False</property>
+																		<property name="angle">0</property>
+																	</widget>
+																</child>
+
+																<child>
+																	<widget class="GtkLabel" id="label49">
+																		<property name="label" translatable="yes">Directory</property>
+																		<property name="use_underline">False</property>
+																		<property name="use_markup">False</property>
+																		<property name="justify">GTK_JUSTIFY_CENTER</property>
+																		<property name="wrap">False</property>
+																		<property name="selectable">False</property>
+																		<property name="xalign">7.45058015283e-09</property>
+																		<property name="yalign">0.5</property>
+																		<property name="xpad">0</property>
+																		<property name="ypad">0</property>
+																		<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+																		<property name="width_chars">-1</property>
+																		<property name="single_line_mode">False</property>
+																		<property name="angle">0</property>
+																	</widget>
+																</child>
+
+																<child>
+																	<widget class="GtkLabel" id="label50">
+																		<property name="label" translatable="yes">Size</property>
+																		<property name="use_underline">False</property>
+																		<property name="use_markup">False</property>
+																		<property name="justify">GTK_JUSTIFY_CENTER</property>
+																		<property name="wrap">False</property>
+																		<property name="selectable">False</property>
+																		<property name="xalign">7.45058015283e-09</property>
+																		<property name="yalign">0.5</property>
+																		<property name="xpad">0</property>
+																		<property name="ypad">0</property>
+																		<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+																		<property name="width_chars">-1</property>
+																		<property name="single_line_mode">False</property>
+																		<property name="angle">0</property>
+																	</widget>
+																</child>
+
+																<child>
+																	<widget class="GtkLabel" id="label51">
+																		<property name="label" translatable="yes">Date</property>
+																		<property name="use_underline">False</property>
+																		<property name="use_markup">False</property>
+																		<property name="justify">GTK_JUSTIFY_CENTER</property>
+																		<property name="wrap">False</property>
+																		<property name="selectable">False</property>
+																		<property name="xalign">7.45058015283e-09</property>
+																		<property name="yalign">0.5</property>
+																		<property name="xpad">0</property>
+																		<property name="ypad">0</property>
+																		<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+																		<property name="width_chars">-1</property>
+																		<property name="single_line_mode">False</property>
+																		<property name="angle">0</property>
+																	</widget>
+																</child>
+															</widget>
+														</child>
+													</widget>
+													<packing>
+														<property name="padding">0</property>
+														<property name="expand">True</property>
+														<property name="fill">True</property>
+													</packing>
+												</child>
+											</widget>
+											<packing>
+												<property name="tab_expand">False</property>
+												<property name="tab_fill">True</property>
+											</packing>
+										</child>
+
+										<child>
+											<widget class="GtkLabel" id="rs">
+												<property name="visible">True</property>
+												<property name="label" translatable="yes">Redundant whitespace</property>
+												<property name="use_underline">False</property>
+												<property name="use_markup">False</property>
+												<property name="justify">GTK_JUSTIFY_CENTER</property>
+												<property name="wrap">False</property>
+												<property name="selectable">False</property>
+												<property name="xalign">0.5</property>
+												<property name="yalign">0.5</property>
+												<property name="xpad">0</property>
+												<property name="ypad">0</property>
+												<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+												<property name="width_chars">-1</property>
+												<property name="single_line_mode">False</property>
+												<property name="angle">0</property>
+											</widget>
+											<packing>
+												<property name="type">tab</property>
+											</packing>
+										</child>
+									</widget>
+									<packing>
+										<property name="padding">3</property>
+										<property name="expand">True</property>
+										<property name="fill">True</property>
+									</packing>
+								</child>
+
+								<child>
+									<widget class="GtkHBox" id="hbox20">
+										<property name="visible">True</property>
+										<property name="homogeneous">False</property>
+										<property name="spacing">0</property>
+
+										<child>
+											<widget class="GtkHBox" id="control_buttons">
+												<property name="visible">True</property>
+												<property name="homogeneous">False</property>
+												<property name="spacing">0</property>
+												<signal name="key_press_event" handler="on_control_buttons_keypress" last_modification_time="Wed, 15 Jul 2009 10:32:48 GMT"/>
+
+												<child>
+													<widget class="GtkButton" id="find">
+														<property name="visible">True</property>
+														<property name="can_default">True</property>
+														<property name="can_focus">True</property>
+														<property name="relief">GTK_RELIEF_NORMAL</property>
+														<property name="focus_on_click">True</property>
+														<signal name="clicked" handler="on_find_clicked"/>
+
+														<child>
+															<widget class="GtkAlignment" id="alignment12">
+																<property name="visible">True</property>
+																<property name="xalign">0.5</property>
+																<property name="yalign">0.5</property>
+																<property name="xscale">0</property>
+																<property name="yscale">0</property>
+																<property name="top_padding">0</property>
+																<property name="bottom_padding">0</property>
+																<property name="left_padding">0</property>
+																<property name="right_padding">2</property>
+
+																<child>
+																	<widget class="GtkHBox" id="hbox21">
+																		<property name="visible">True</property>
+																		<property name="homogeneous">False</property>
+																		<property name="spacing">2</property>
+
+																		<child>
+																			<widget class="GtkImage" id="image12">
+																				<property name="visible">True</property>
+																				<property name="stock">gtk-find</property>
+																				<property name="icon_size">4</property>
+																				<property name="xalign">0.5</property>
+																				<property name="yalign">0.5</property>
+																				<property name="xpad">0</property>
+																				<property name="ypad">0</property>
+																			</widget>
+																			<packing>
+																				<property name="padding">0</property>
+																				<property name="expand">False</property>
+																				<property name="fill">False</property>
+																			</packing>
+																		</child>
+
+																		<child>
+																			<widget class="GtkLabel" id="label66">
+																				<property name="visible">True</property>
+																				<property name="label" translatable="yes">Find</property>
+																				<property name="use_underline">True</property>
+																				<property name="use_markup">False</property>
+																				<property name="justify">GTK_JUSTIFY_LEFT</property>
+																				<property name="wrap">False</property>
+																				<property name="selectable">False</property>
+																				<property name="xalign">0.5</property>
+																				<property name="yalign">0.5</property>
+																				<property name="xpad">0</property>
+																				<property name="ypad">0</property>
+																				<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+																				<property name="width_chars">-1</property>
+																				<property name="single_line_mode">False</property>
+																				<property name="angle">0</property>
+																			</widget>
+																			<packing>
+																				<property name="padding">0</property>
+																				<property name="expand">False</property>
+																				<property name="fill">False</property>
+																			</packing>
+																		</child>
+																	</widget>
+																</child>
+															</widget>
+														</child>
+													</widget>
+													<packing>
+														<property name="padding">1</property>
+														<property name="expand">False</property>
+														<property name="fill">False</property>
+													</packing>
+												</child>
+
+												<child>
+													<widget class="GtkButton" id="stop">
+														<property name="can_default">True</property>
+														<property name="can_focus">True</property>
+														<property name="relief">GTK_RELIEF_NORMAL</property>
+														<property name="focus_on_click">True</property>
+														<signal name="clicked" handler="on_stop_clicked" last_modification_time="Thu, 06 Mar 2003 19:09:18 GMT"/>
+
+														<child>
+															<widget class="GtkAlignment" id="alignment4">
+																<property name="visible">True</property>
+																<property name="xalign">0.5</property>
+																<property name="yalign">0.5</property>
+																<property name="xscale">0</property>
+																<property name="yscale">0</property>
+																<property name="top_padding">0</property>
+																<property name="bottom_padding">0</property>
+																<property name="left_padding">0</property>
+																<property name="right_padding">2</property>
+
+																<child>
+																	<widget class="GtkHBox" id="hbox12">
+																		<property name="visible">True</property>
+																		<property name="homogeneous">False</property>
+																		<property name="spacing">2</property>
+
+																		<child>
+																			<widget class="GtkImage" id="image4">
+																				<property name="visible">True</property>
+																				<property name="stock">gtk-stop</property>
+																				<property name="icon_size">4</property>
+																				<property name="xalign">0.5</property>
+																				<property name="yalign">0.5</property>
+																				<property name="xpad">0</property>
+																				<property name="ypad">0</property>
+																			</widget>
+																			<packing>
+																				<property name="padding">0</property>
+																				<property name="expand">False</property>
+																				<property name="fill">False</property>
+																			</packing>
+																		</child>
+
+																		<child>
+																			<widget class="GtkLabel" id="label58">
+																				<property name="visible">True</property>
+																				<property name="label" translatable="yes">Stop</property>
+																				<property name="use_underline">True</property>
+																				<property name="use_markup">False</property>
+																				<property name="justify">GTK_JUSTIFY_LEFT</property>
+																				<property name="wrap">False</property>
+																				<property name="selectable">False</property>
+																				<property name="xalign">0.5</property>
+																				<property name="yalign">0.5</property>
+																				<property name="xpad">0</property>
+																				<property name="ypad">0</property>
+																				<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+																				<property name="width_chars">-1</property>
+																				<property name="single_line_mode">False</property>
+																				<property name="angle">0</property>
+																			</widget>
+																			<packing>
+																				<property name="padding">0</property>
+																				<property name="expand">False</property>
+																				<property name="fill">False</property>
+																			</packing>
+																		</child>
+																	</widget>
+																</child>
+															</widget>
+														</child>
+													</widget>
+													<packing>
+														<property name="padding">1</property>
+														<property name="expand">False</property>
+														<property name="fill">False</property>
+													</packing>
+												</child>
+
+												<child>
+													<widget class="GtkButton" id="pause">
+														<property name="can_default">True</property>
+														<property name="can_focus">True</property>
+														<property name="relief">GTK_RELIEF_NORMAL</property>
+														<property name="focus_on_click">True</property>
+														<signal name="clicked" handler="on_pause_clicked" last_modification_time="Tue, 07 Jul 2009 21:28:03 GMT"/>
+
+														<child>
+															<widget class="GtkAlignment" id="alignment17">
+																<property name="visible">True</property>
+																<property name="xalign">0.5</property>
+																<property name="yalign">0.5</property>
+																<property name="xscale">0</property>
+																<property name="yscale">0</property>
+																<property name="top_padding">0</property>
+																<property name="bottom_padding">0</property>
+																<property name="left_padding">0</property>
+																<property name="right_padding">2</property>
+
+																<child>
+																	<widget class="GtkHBox" id="hbox29">
+																		<property name="visible">True</property>
+																		<property name="homogeneous">False</property>
+																		<property name="spacing">2</property>
+
+																		<child>
+																			<widget class="GtkImage" id="image17">
+																				<property name="visible">True</property>
+																				<property name="stock">gtk-media-pause</property>
+																				<property name="icon_size">4</property>
+																				<property name="xalign">0.5</property>
+																				<property name="yalign">0.5</property>
+																				<property name="xpad">0</property>
+																				<property name="ypad">0</property>
+																			</widget>
+																			<packing>
+																				<property name="padding">0</property>
+																				<property name="expand">False</property>
+																				<property name="fill">False</property>
+																			</packing>
+																		</child>
+
+																		<child>
+																			<widget class="GtkLabel" id="label75">
+																				<property name="visible">True</property>
+																				<property name="label" translatable="yes">Pause</property>
+																				<property name="use_underline">True</property>
+																				<property name="use_markup">False</property>
+																				<property name="justify">GTK_JUSTIFY_LEFT</property>
+																				<property name="wrap">False</property>
+																				<property name="selectable">False</property>
+																				<property name="xalign">0.5</property>
+																				<property name="yalign">0.5</property>
+																				<property name="xpad">0</property>
+																				<property name="ypad">0</property>
+																				<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+																				<property name="width_chars">-1</property>
+																				<property name="single_line_mode">False</property>
+																				<property name="angle">0</property>
+																			</widget>
+																			<packing>
+																				<property name="padding">0</property>
+																				<property name="expand">False</property>
+																				<property name="fill">False</property>
+																			</packing>
+																		</child>
+																	</widget>
+																</child>
+															</widget>
+														</child>
+													</widget>
+													<packing>
+														<property name="padding">1</property>
+														<property name="expand">False</property>
+														<property name="fill">False</property>
+													</packing>
+												</child>
+
+												<child>
+													<widget class="GtkButton" id="resume">
+														<property name="can_default">True</property>
+														<property name="can_focus">True</property>
+														<property name="relief">GTK_RELIEF_NORMAL</property>
+														<property name="focus_on_click">True</property>
+														<signal name="clicked" handler="on_pause_clicked" last_modification_time="Tue, 07 Jul 2009 21:28:33 GMT"/>
+
+														<child>
+															<widget class="GtkAlignment" id="alignment18">
+																<property name="visible">True</property>
+																<property name="xalign">0.5</property>
+																<property name="yalign">0.5</property>
+																<property name="xscale">0</property>
+																<property name="yscale">0</property>
+																<property name="top_padding">0</property>
+																<property name="bottom_padding">0</property>
+																<property name="left_padding">0</property>
+																<property name="right_padding">2</property>
+
+																<child>
+																	<widget class="GtkHBox" id="hbox30">
+																		<property name="visible">True</property>
+																		<property name="homogeneous">False</property>
+																		<property name="spacing">2</property>
+
+																		<child>
+																			<widget class="GtkImage" id="image18">
+																				<property name="visible">True</property>
+																				<property name="stock">gtk-media-play</property>
+																				<property name="icon_size">4</property>
+																				<property name="xalign">0.5</property>
+																				<property name="yalign">0.5</property>
+																				<property name="xpad">0</property>
+																				<property name="ypad">0</property>
+																			</widget>
+																			<packing>
+																				<property name="padding">0</property>
+																				<property name="expand">False</property>
+																				<property name="fill">False</property>
+																			</packing>
+																		</child>
+
+																		<child>
+																			<widget class="GtkLabel" id="label76">
+																				<property name="visible">True</property>
+																				<property name="label" translatable="yes">Resume</property>
+																				<property name="use_underline">True</property>
+																				<property name="use_markup">False</property>
+																				<property name="justify">GTK_JUSTIFY_LEFT</property>
+																				<property name="wrap">False</property>
+																				<property name="selectable">False</property>
+																				<property name="xalign">0.5</property>
+																				<property name="yalign">0.5</property>
+																				<property name="xpad">0</property>
+																				<property name="ypad">0</property>
+																				<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+																				<property name="width_chars">-1</property>
+																				<property name="single_line_mode">False</property>
+																				<property name="angle">0</property>
+																			</widget>
+																			<packing>
+																				<property name="padding">0</property>
+																				<property name="expand">False</property>
+																				<property name="fill">False</property>
+																			</packing>
+																		</child>
+																	</widget>
+																</child>
+															</widget>
+														</child>
+													</widget>
+													<packing>
+														<property name="padding">1</property>
+														<property name="expand">False</property>
+														<property name="fill">False</property>
+													</packing>
+												</child>
+											</widget>
+											<packing>
+												<property name="padding">0</property>
+												<property name="expand">True</property>
+												<property name="fill">True</property>
+											</packing>
+										</child>
+
+										<child>
+											<widget class="GtkHButtonBox" id="action_buttons">
+												<property name="visible">True</property>
+												<property name="layout_style">GTK_BUTTONBOX_END</property>
+												<property name="spacing">2</property>
+
+												<child>
+													<widget class="GtkButton" id="selection">
+														<property name="visible">True</property>
+														<property name="can_default">True</property>
+														<property name="can_focus">True</property>
+														<property name="relief">GTK_RELIEF_NORMAL</property>
+														<property name="focus_on_click">True</property>
+														<signal name="clicked" handler="on_selection_clicked" last_modification_time="Mon, 18 Dec 2006 08:20:59 GMT"/>
+
+														<child>
+															<widget class="GtkAlignment" id="alignment5">
+																<property name="visible">True</property>
+																<property name="xalign">0.5</property>
+																<property name="yalign">0.5</property>
+																<property name="xscale">0</property>
+																<property name="yscale">0</property>
+																<property name="top_padding">0</property>
+																<property name="bottom_padding">0</property>
+																<property name="left_padding">0</property>
+																<property name="right_padding">0</property>
+
+																<child>
+																	<widget class="GtkHBox" id="hbox13">
+																		<property name="visible">True</property>
+																		<property name="homogeneous">False</property>
+																		<property name="spacing">2</property>
+
+																		<child>
+																			<widget class="GtkImage" id="image5">
+																				<property name="visible">True</property>
+																				<property name="stock">gtk-index</property>
+																				<property name="icon_size">4</property>
+																				<property name="xalign">0.5</property>
+																				<property name="yalign">0.5</property>
+																				<property name="xpad">0</property>
+																				<property name="ypad">0</property>
+																			</widget>
+																			<packing>
+																				<property name="padding">0</property>
+																				<property name="expand">False</property>
+																				<property name="fill">False</property>
+																			</packing>
+																		</child>
+
+																		<child>
+																			<widget class="GtkLabel" id="label59">
+																				<property name="visible">True</property>
+																				<property name="label" translatable="yes">Select</property>
+																				<property name="use_underline">True</property>
+																				<property name="use_markup">False</property>
+																				<property name="justify">GTK_JUSTIFY_LEFT</property>
+																				<property name="wrap">False</property>
+																				<property name="selectable">False</property>
+																				<property name="xalign">0.5</property>
+																				<property name="yalign">0.5</property>
+																				<property name="xpad">0</property>
+																				<property name="ypad">0</property>
+																				<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+																				<property name="width_chars">-1</property>
+																				<property name="single_line_mode">False</property>
+																				<property name="angle">0</property>
+																			</widget>
+																			<packing>
+																				<property name="padding">0</property>
+																				<property name="expand">False</property>
+																				<property name="fill">False</property>
+																			</packing>
+																		</child>
+																	</widget>
+																</child>
+															</widget>
+														</child>
+													</widget>
+												</child>
+
+												<child>
+													<widget class="GtkButton" id="saveAs">
+														<property name="visible">True</property>
+														<property name="tooltip" translatable="yes">Save (selected) list to file</property>
+														<property name="can_default">True</property>
+														<property name="can_focus">True</property>
+														<property name="relief">GTK_RELIEF_NORMAL</property>
+														<property name="focus_on_click">True</property>
+														<signal name="clicked" handler="on_saveAs_clicked"/>
+
+														<child>
+															<widget class="GtkAlignment" id="alignment6">
+																<property name="visible">True</property>
+																<property name="xalign">0.5</property>
+																<property name="yalign">0.5</property>
+																<property name="xscale">0</property>
+																<property name="yscale">0</property>
+																<property name="top_padding">0</property>
+																<property name="bottom_padding">0</property>
+																<property name="left_padding">0</property>
+																<property name="right_padding">0</property>
+
+																<child>
+																	<widget class="GtkHBox" id="hbox14">
+																		<property name="visible">True</property>
+																		<property name="homogeneous">False</property>
+																		<property name="spacing">2</property>
+
+																		<child>
+																			<widget class="GtkImage" id="image6">
+																				<property name="visible">True</property>
+																				<property name="stock">gtk-save-as</property>
+																				<property name="icon_size">4</property>
+																				<property name="xalign">0.5</property>
+																				<property name="yalign">0.5</property>
+																				<property name="xpad">0</property>
+																				<property name="ypad">0</property>
+																			</widget>
+																			<packing>
+																				<property name="padding">0</property>
+																				<property name="expand">False</property>
+																				<property name="fill">False</property>
+																			</packing>
+																		</child>
+
+																		<child>
+																			<widget class="GtkLabel" id="label60">
+																				<property name="visible">True</property>
+																				<property name="label" translatable="yes">Save</property>
+																				<property name="use_underline">True</property>
+																				<property name="use_markup">False</property>
+																				<property name="justify">GTK_JUSTIFY_LEFT</property>
+																				<property name="wrap">False</property>
+																				<property name="selectable">False</property>
+																				<property name="xalign">0.5</property>
+																				<property name="yalign">0.5</property>
+																				<property name="xpad">0</property>
+																				<property name="ypad">0</property>
+																				<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+																				<property name="width_chars">-1</property>
+																				<property name="single_line_mode">False</property>
+																				<property name="angle">0</property>
+																			</widget>
+																			<packing>
+																				<property name="padding">0</property>
+																				<property name="expand">False</property>
+																				<property name="fill">False</property>
+																			</packing>
+																		</child>
+																	</widget>
+																</child>
+															</widget>
+														</child>
+													</widget>
+												</child>
+
+												<child>
+													<widget class="GtkButton" id="delSelected">
+														<property name="visible">True</property>
+														<property name="tooltip" translatable="yes">selected</property>
+														<property name="can_default">True</property>
+														<property name="can_focus">True</property>
+														<property name="relief">GTK_RELIEF_NORMAL</property>
+														<property name="focus_on_click">True</property>
+														<signal name="clicked" handler="on_delSelected_clicked"/>
+
+														<child>
+															<widget class="GtkAlignment" id="alignment7">
+																<property name="visible">True</property>
+																<property name="xalign">0.5</property>
+																<property name="yalign">0.5</property>
+																<property name="xscale">0</property>
+																<property name="yscale">0</property>
+																<property name="top_padding">0</property>
+																<property name="bottom_padding">0</property>
+																<property name="left_padding">0</property>
+																<property name="right_padding">0</property>
+
+																<child>
+																	<widget class="GtkHBox" id="hbox15">
+																		<property name="visible">True</property>
+																		<property name="homogeneous">False</property>
+																		<property name="spacing">2</property>
+
+																		<child>
+																			<widget class="GtkImage" id="image7">
+																				<property name="visible">True</property>
+																				<property name="stock">gtk-delete</property>
+																				<property name="icon_size">4</property>
+																				<property name="xalign">0.5</property>
+																				<property name="yalign">0.5</property>
+																				<property name="xpad">0</property>
+																				<property name="ypad">0</property>
+																			</widget>
+																			<packing>
+																				<property name="padding">0</property>
+																				<property name="expand">False</property>
+																				<property name="fill">False</property>
+																			</packing>
+																		</child>
+
+																		<child>
+																			<widget class="GtkLabel" id="label61">
+																				<property name="visible">True</property>
+																				<property name="label" translatable="yes">Delete</property>
+																				<property name="use_underline">True</property>
+																				<property name="use_markup">False</property>
+																				<property name="justify">GTK_JUSTIFY_LEFT</property>
+																				<property name="wrap">False</property>
+																				<property name="selectable">False</property>
+																				<property name="xalign">0.5</property>
+																				<property name="yalign">0.5</property>
+																				<property name="xpad">0</property>
+																				<property name="ypad">0</property>
+																				<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+																				<property name="width_chars">-1</property>
+																				<property name="single_line_mode">False</property>
+																				<property name="angle">0</property>
+																			</widget>
+																			<packing>
+																				<property name="padding">0</property>
+																				<property name="expand">False</property>
+																				<property name="fill">False</property>
+																			</packing>
+																		</child>
+																	</widget>
+																</child>
+															</widget>
+														</child>
+													</widget>
+												</child>
+
+												<child>
+													<widget class="GtkButton" id="autoMerge">
+														<property name="visible">True</property>
+														<property name="tooltip" translatable="yes">All (except selected) using hardlinks
 (or symlinks if on a different filesystem)</property>
-			  <property name="can_default">True</property>
-			  <property name="can_focus">True</property>
-			  <property name="relief">GTK_RELIEF_NORMAL</property>
-			  <property name="focus_on_click">True</property>
-			  <signal name="clicked" handler="on_autoMerge_clicked"/>
+														<property name="can_default">True</property>
+														<property name="can_focus">True</property>
+														<property name="relief">GTK_RELIEF_NORMAL</property>
+														<property name="focus_on_click">True</property>
+														<signal name="clicked" handler="on_autoMerge_clicked"/>
 
-			  <child>
-			    <widget class="GtkAlignment" id="alignment9">
-			      <property name="visible">True</property>
-			      <property name="xalign">0.5</property>
-			      <property name="yalign">0.5</property>
-			      <property name="xscale">0</property>
-			      <property name="yscale">0</property>
-			      <property name="top_padding">0</property>
-			      <property name="bottom_padding">0</property>
-			      <property name="left_padding">0</property>
-			      <property name="right_padding">0</property>
+														<child>
+															<widget class="GtkAlignment" id="alignment9">
+																<property name="visible">True</property>
+																<property name="xalign">0.5</property>
+																<property name="yalign">0.5</property>
+																<property name="xscale">0</property>
+																<property name="yscale">0</property>
+																<property name="top_padding">0</property>
+																<property name="bottom_padding">0</property>
+																<property name="left_padding">0</property>
+																<property name="right_padding">0</property>
 
-			      <child>
-				<widget class="GtkHBox" id="hbox17">
-				  <property name="visible">True</property>
-				  <property name="homogeneous">False</property>
-				  <property name="spacing">2</property>
+																<child>
+																	<widget class="GtkHBox" id="hbox17">
+																		<property name="visible">True</property>
+																		<property name="homogeneous">False</property>
+																		<property name="spacing">2</property>
 
-				  <child>
-				    <widget class="GtkImage" id="image9">
-				      <property name="visible">True</property>
-				      <property name="stock">gtk-media-forward</property>
-				      <property name="icon_size">4</property>
-				      <property name="xalign">0.5</property>
-				      <property name="yalign">0.5</property>
-				      <property name="xpad">0</property>
-				      <property name="ypad">0</property>
-				    </widget>
-				    <packing>
-				      <property name="padding">0</property>
-				      <property name="expand">False</property>
-				      <property name="fill">False</property>
-				    </packing>
-				  </child>
+																		<child>
+																			<widget class="GtkImage" id="image9">
+																				<property name="visible">True</property>
+																				<property name="stock">gtk-media-forward</property>
+																				<property name="icon_size">4</property>
+																				<property name="xalign">0.5</property>
+																				<property name="yalign">0.5</property>
+																				<property name="xpad">0</property>
+																				<property name="ypad">0</property>
+																			</widget>
+																			<packing>
+																				<property name="padding">0</property>
+																				<property name="expand">False</property>
+																				<property name="fill">False</property>
+																			</packing>
+																		</child>
 
-				  <child>
-				    <widget class="GtkLabel" id="label63">
-				      <property name="visible">True</property>
-				      <property name="label" translatable="yes">Merge</property>
-				      <property name="use_underline">True</property>
-				      <property name="use_markup">False</property>
-				      <property name="justify">GTK_JUSTIFY_LEFT</property>
-				      <property name="wrap">False</property>
-				      <property name="selectable">False</property>
-				      <property name="xalign">0.5</property>
-				      <property name="yalign">0.5</property>
-				      <property name="xpad">0</property>
-				      <property name="ypad">0</property>
-				      <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-				      <property name="width_chars">-1</property>
-				      <property name="single_line_mode">False</property>
-				      <property name="angle">0</property>
-				    </widget>
-				    <packing>
-				      <property name="padding">0</property>
-				      <property name="expand">False</property>
-				      <property name="fill">False</property>
-				    </packing>
-				  </child>
-				</widget>
-			      </child>
-			    </widget>
-			  </child>
+																		<child>
+																			<widget class="GtkLabel" id="label63">
+																				<property name="visible">True</property>
+																				<property name="label" translatable="yes">Merge</property>
+																				<property name="use_underline">True</property>
+																				<property name="use_markup">False</property>
+																				<property name="justify">GTK_JUSTIFY_LEFT</property>
+																				<property name="wrap">False</property>
+																				<property name="selectable">False</property>
+																				<property name="xalign">0.5</property>
+																				<property name="yalign">0.5</property>
+																				<property name="xpad">0</property>
+																				<property name="ypad">0</property>
+																				<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+																				<property name="width_chars">-1</property>
+																				<property name="single_line_mode">False</property>
+																				<property name="angle">0</property>
+																			</widget>
+																			<packing>
+																				<property name="padding">0</property>
+																				<property name="expand">False</property>
+																				<property name="fill">False</property>
+																			</packing>
+																		</child>
+																	</widget>
+																</child>
+															</widget>
+														</child>
+													</widget>
+												</child>
+
+												<child>
+													<widget class="GtkButton" id="autoClean">
+														<property name="tooltip" translatable="yes">selected</property>
+														<property name="can_default">True</property>
+														<property name="can_focus">True</property>
+														<property name="relief">GTK_RELIEF_NORMAL</property>
+														<property name="focus_on_click">True</property>
+														<signal name="clicked" handler="on_autoClean_clicked"/>
+
+														<child>
+															<widget class="GtkAlignment" id="alignment8">
+																<property name="visible">True</property>
+																<property name="xalign">0.5</property>
+																<property name="yalign">0.5</property>
+																<property name="xscale">0</property>
+																<property name="yscale">0</property>
+																<property name="top_padding">0</property>
+																<property name="bottom_padding">0</property>
+																<property name="left_padding">0</property>
+																<property name="right_padding">0</property>
+
+																<child>
+																	<widget class="GtkHBox" id="hbox16">
+																		<property name="visible">True</property>
+																		<property name="homogeneous">False</property>
+																		<property name="spacing">2</property>
+
+																		<child>
+																			<widget class="GtkImage" id="image8">
+																				<property name="visible">True</property>
+																				<property name="stock">gtk-clear</property>
+																				<property name="icon_size">4</property>
+																				<property name="xalign">0.5</property>
+																				<property name="yalign">0.5</property>
+																				<property name="xpad">0</property>
+																				<property name="ypad">0</property>
+																			</widget>
+																			<packing>
+																				<property name="padding">0</property>
+																				<property name="expand">False</property>
+																				<property name="fill">False</property>
+																			</packing>
+																		</child>
+
+																		<child>
+																			<widget class="GtkLabel" id="label62">
+																				<property name="visible">True</property>
+																				<property name="label" translatable="yes">Clean</property>
+																				<property name="use_underline">True</property>
+																				<property name="use_markup">False</property>
+																				<property name="justify">GTK_JUSTIFY_LEFT</property>
+																				<property name="wrap">False</property>
+																				<property name="selectable">False</property>
+																				<property name="xalign">0.5</property>
+																				<property name="yalign">0.5</property>
+																				<property name="xpad">0</property>
+																				<property name="ypad">0</property>
+																				<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+																				<property name="width_chars">-1</property>
+																				<property name="single_line_mode">False</property>
+																				<property name="angle">0</property>
+																			</widget>
+																			<packing>
+																				<property name="padding">0</property>
+																				<property name="expand">False</property>
+																				<property name="fill">False</property>
+																			</packing>
+																		</child>
+																	</widget>
+																</child>
+															</widget>
+														</child>
+													</widget>
+												</child>
+
+												<child>
+													<widget class="GtkButton" id="autoSymlink">
+														<property name="visible">True</property>
+														<property name="tooltip" translatable="yes">All (except selected) using symbolic links</property>
+														<property name="can_default">True</property>
+														<property name="can_focus">True</property>
+														<property name="relief">GTK_RELIEF_NORMAL</property>
+														<property name="focus_on_click">True</property>
+														<signal name="clicked" handler="on_autoSymlink_clicked" last_modification_time="Sat, 21 Jan 2017 13:58:13 GMT"/>
+
+														<child>
+															<widget class="GtkAlignment" id="alignment19">
+																<property name="visible">True</property>
+																<property name="xalign">0.5</property>
+																<property name="yalign">0.5</property>
+																<property name="xscale">0</property>
+																<property name="yscale">0</property>
+																<property name="top_padding">0</property>
+																<property name="bottom_padding">0</property>
+																<property name="left_padding">0</property>
+																<property name="right_padding">0</property>
+
+																<child>
+																	<widget class="GtkHBox" id="hbox32">
+																		<property name="visible">True</property>
+																		<property name="homogeneous">False</property>
+																		<property name="spacing">2</property>
+
+																		<child>
+																			<widget class="GtkImage" id="image19">
+																				<property name="visible">True</property>
+																				<property name="stock">gtk-go-forward</property>
+																				<property name="icon_size">4</property>
+																				<property name="xalign">0.5</property>
+																				<property name="yalign">0.5</property>
+																				<property name="xpad">0</property>
+																				<property name="ypad">0</property>
+																			</widget>
+																			<packing>
+																				<property name="padding">0</property>
+																				<property name="expand">False</property>
+																				<property name="fill">False</property>
+																			</packing>
+																		</child>
+
+																		<child>
+																			<widget class="GtkLabel" id="label78">
+																				<property name="visible">True</property>
+																				<property name="label" translatable="yes">Symlink</property>
+																				<property name="use_underline">True</property>
+																				<property name="use_markup">False</property>
+																				<property name="justify">GTK_JUSTIFY_LEFT</property>
+																				<property name="wrap">False</property>
+																				<property name="selectable">False</property>
+																				<property name="xalign">0.5</property>
+																				<property name="yalign">0.5</property>
+																				<property name="xpad">0</property>
+																				<property name="ypad">0</property>
+																				<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+																				<property name="width_chars">-1</property>
+																				<property name="single_line_mode">False</property>
+																				<property name="angle">0</property>
+																			</widget>
+																			<packing>
+																				<property name="padding">0</property>
+																				<property name="expand">False</property>
+																				<property name="fill">False</property>
+																			</packing>
+																		</child>
+																	</widget>
+																</child>
+															</widget>
+														</child>
+													</widget>
+												</child>
+											</widget>
+											<packing>
+												<property name="padding">0</property>
+												<property name="expand">False</property>
+												<property name="fill">False</property>
+											</packing>
+										</child>
+									</widget>
+									<packing>
+										<property name="padding">0</property>
+										<property name="expand">False</property>
+										<property name="fill">False</property>
+									</packing>
+								</child>
+
+								<child>
+									<widget class="GtkScrolledWindow" id="scrolledwindow13">
+										<property name="visible">True</property>
+										<property name="can_focus">True</property>
+										<property name="hscrollbar_policy">GTK_POLICY_NEVER</property>
+										<property name="vscrollbar_policy">GTK_POLICY_NEVER</property>
+										<property name="shadow_type">GTK_SHADOW_IN</property>
+										<property name="window_placement">GTK_CORNER_TOP_LEFT</property>
+
+										<child>
+											<widget class="GtkViewport" id="viewport1">
+												<property name="visible">True</property>
+												<property name="shadow_type">GTK_SHADOW_NONE</property>
+
+												<child>
+													<widget class="GtkEntry" id="status">
+														<property name="visible">True</property>
+														<property name="can_focus">True</property>
+														<property name="editable">False</property>
+														<property name="visibility">True</property>
+														<property name="max_length">0</property>
+														<property name="text"></property>
+														<property name="has_frame">False</property>
+														<property name="invisible_char">*</property>
+														<property name="activates_default">False</property>
+													</widget>
+												</child>
+											</widget>
+										</child>
+									</widget>
+									<packing>
+										<property name="padding">3</property>
+										<property name="expand">False</property>
+										<property name="fill">False</property>
+									</packing>
+								</child>
+							</widget>
+							<packing>
+								<property name="shrink">True</property>
+								<property name="resize">True</property>
+							</packing>
+						</child>
+
+						<child>
+							<widget class="GtkScrolledWindow" id="scrolledwindow14">
+								<property name="visible">True</property>
+								<property name="can_focus">True</property>
+								<property name="hscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
+								<property name="vscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
+								<property name="shadow_type">GTK_SHADOW_IN</property>
+								<property name="window_placement">GTK_CORNER_TOP_LEFT</property>
+
+								<child>
+									<widget class="GtkTextView" id="errors">
+										<property name="visible">True</property>
+										<property name="can_focus">True</property>
+										<property name="editable">False</property>
+										<property name="overwrite">False</property>
+										<property name="accepts_tab">True</property>
+										<property name="justification">GTK_JUSTIFY_LEFT</property>
+										<property name="wrap_mode">GTK_WRAP_NONE</property>
+										<property name="cursor_visible">True</property>
+										<property name="pixels_above_lines">0</property>
+										<property name="pixels_below_lines">0</property>
+										<property name="pixels_inside_wrap">0</property>
+										<property name="left_margin">0</property>
+										<property name="right_margin">0</property>
+										<property name="indent">0</property>
+										<property name="text" translatable="yes"></property>
+									</widget>
+								</child>
+							</widget>
+							<packing>
+								<property name="shrink">True</property>
+								<property name="resize">True</property>
+							</packing>
+						</child>
+					</widget>
+					<packing>
+						<property name="padding">3</property>
+						<property name="expand">True</property>
+						<property name="fill">True</property>
+					</packing>
+				</child>
 			</widget>
-		      </child>
+		</child>
+	</widget>
 
-		      <child>
-			<widget class="GtkButton" id="autoClean">
-			  <property name="tooltip" translatable="yes">selected</property>
-			  <property name="can_default">True</property>
-			  <property name="can_focus">True</property>
-			  <property name="relief">GTK_RELIEF_NORMAL</property>
-			  <property name="focus_on_click">True</property>
-			  <signal name="clicked" handler="on_autoClean_clicked"/>
+	<widget class="GtkFileChooserDialog" id="PathChoose">
+		<property name="border_width">5</property>
+		<property name="action">GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER</property>
+		<property name="local_only">True</property>
+		<property name="select_multiple">True</property>
+		<property name="show_hidden">False</property>
+		<property name="do_overwrite_confirmation">False</property>
+		<property name="title" translatable="yes">Select Path</property>
+		<property name="type">GTK_WINDOW_TOPLEVEL</property>
+		<property name="window_position">GTK_WIN_POS_NONE</property>
+		<property name="modal">True</property>
+		<property name="resizable">True</property>
+		<property name="destroy_with_parent">False</property>
+		<property name="role">GtkFileChooserDialog</property>
+		<property name="decorated">True</property>
+		<property name="skip_taskbar_hint">False</property>
+		<property name="skip_pager_hint">False</property>
+		<property name="type_hint">GDK_WINDOW_TYPE_HINT_DIALOG</property>
+		<property name="gravity">GDK_GRAVITY_NORTH_WEST</property>
+		<property name="focus_on_map">True</property>
+		<property name="urgency_hint">False</property>
+		<signal name="delete_event" handler="quit" last_modification_time="Mon, 22 Jun 2009 18:33:11 GMT"/>
 
-			  <child>
-			    <widget class="GtkAlignment" id="alignment8">
-			      <property name="visible">True</property>
-			      <property name="xalign">0.5</property>
-			      <property name="yalign">0.5</property>
-			      <property name="xscale">0</property>
-			      <property name="yscale">0</property>
-			      <property name="top_padding">0</property>
-			      <property name="bottom_padding">0</property>
-			      <property name="left_padding">0</property>
-			      <property name="right_padding">0</property>
+		<child internal-child="vbox">
+			<widget class="GtkVBox" id="dialog-vbox2">
+				<property name="visible">True</property>
+				<property name="homogeneous">False</property>
+				<property name="spacing">2</property>
 
-			      <child>
-				<widget class="GtkHBox" id="hbox16">
-				  <property name="visible">True</property>
-				  <property name="homogeneous">False</property>
-				  <property name="spacing">2</property>
+				<child internal-child="action_area">
+					<widget class="GtkHButtonBox" id="dialog-action_area2">
+						<property name="visible">True</property>
+						<property name="layout_style">GTK_BUTTONBOX_END</property>
 
-				  <child>
-				    <widget class="GtkImage" id="image8">
-				      <property name="visible">True</property>
-				      <property name="stock">gtk-clear</property>
-				      <property name="icon_size">4</property>
-				      <property name="xalign">0.5</property>
-				      <property name="yalign">0.5</property>
-				      <property name="xpad">0</property>
-				      <property name="ypad">0</property>
-				    </widget>
-				    <packing>
-				      <property name="padding">0</property>
-				      <property name="expand">False</property>
-				      <property name="fill">False</property>
-				    </packing>
-				  </child>
+						<child>
+							<widget class="GtkButton" id="cancel_path">
+								<property name="visible">True</property>
+								<property name="can_default">True</property>
+								<property name="can_focus">True</property>
+								<property name="label">gtk-cancel</property>
+								<property name="use_stock">True</property>
+								<property name="relief">GTK_RELIEF_NORMAL</property>
+								<property name="focus_on_click">True</property>
+								<property name="response_id">0</property>
+								<signal name="clicked" handler="quit" last_modification_time="Mon, 22 Jun 2009 18:30:54 GMT"/>
+							</widget>
+						</child>
 
-				  <child>
-				    <widget class="GtkLabel" id="label62">
-				      <property name="visible">True</property>
-				      <property name="label" translatable="yes">Clean</property>
-				      <property name="use_underline">True</property>
-				      <property name="use_markup">False</property>
-				      <property name="justify">GTK_JUSTIFY_LEFT</property>
-				      <property name="wrap">False</property>
-				      <property name="selectable">False</property>
-				      <property name="xalign">0.5</property>
-				      <property name="yalign">0.5</property>
-				      <property name="xpad">0</property>
-				      <property name="ypad">0</property>
-				      <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-				      <property name="width_chars">-1</property>
-				      <property name="single_line_mode">False</property>
-				      <property name="angle">0</property>
-				    </widget>
-				    <packing>
-				      <property name="padding">0</property>
-				      <property name="expand">False</property>
-				      <property name="fill">False</property>
-				    </packing>
-				  </child>
-				</widget>
-			      </child>
-			    </widget>
-			  </child>
+						<child>
+							<widget class="GtkButton" id="ok_path">
+								<property name="visible">True</property>
+								<property name="can_default">True</property>
+								<property name="has_default">True</property>
+								<property name="can_focus">True</property>
+								<property name="label">gtk-ok</property>
+								<property name="use_stock">True</property>
+								<property name="relief">GTK_RELIEF_NORMAL</property>
+								<property name="focus_on_click">True</property>
+								<property name="response_id">0</property>
+								<signal name="clicked" handler="on_ok_clicked" last_modification_time="Tue, 23 Jun 2009 01:04:14 GMT"/>
+							</widget>
+						</child>
+					</widget>
+					<packing>
+						<property name="padding">0</property>
+						<property name="expand">False</property>
+						<property name="fill">True</property>
+						<property name="pack_type">GTK_PACK_END</property>
+					</packing>
+				</child>
 			</widget>
-		      </child>
+		</child>
+	</widget>
 
-		      <child>
-			<widget class="GtkButton" id="autoSymlink">
-			  <property name="visible">True</property>
-			  <property name="tooltip" translatable="yes">All (except selected) using symbolic links</property>
-			  <property name="can_default">True</property>
-			  <property name="can_focus">True</property>
-			  <property name="relief">GTK_RELIEF_NORMAL</property>
-			  <property name="focus_on_click">True</property>
-			  <signal name="clicked" handler="on_autoSymlink_clicked" last_modification_time="Sat, 21 Jan 2017 13:58:13 GMT"/>
+	<widget class="GtkDialog" id="UserInteraction">
+		<property name="title" translatable="yes"></property>
+		<property name="type">GTK_WINDOW_TOPLEVEL</property>
+		<property name="window_position">GTK_WIN_POS_CENTER_ON_PARENT</property>
+		<property name="modal">True</property>
+		<property name="default_width">150</property>
+		<property name="default_height">100</property>
+		<property name="resizable">True</property>
+		<property name="destroy_with_parent">False</property>
+		<property name="decorated">True</property>
+		<property name="skip_taskbar_hint">False</property>
+		<property name="skip_pager_hint">False</property>
+		<property name="type_hint">GDK_WINDOW_TYPE_HINT_DIALOG</property>
+		<property name="gravity">GDK_GRAVITY_NORTH_WEST</property>
+		<property name="focus_on_map">True</property>
+		<property name="urgency_hint">False</property>
+		<property name="has_separator">True</property>
+		<signal name="destroy" handler="quit"/>
 
-			  <child>
-			    <widget class="GtkAlignment" id="alignment19">
-			      <property name="visible">True</property>
-			      <property name="xalign">0.5</property>
-			      <property name="yalign">0.5</property>
-			      <property name="xscale">0</property>
-			      <property name="yscale">0</property>
-			      <property name="top_padding">0</property>
-			      <property name="bottom_padding">0</property>
-			      <property name="left_padding">0</property>
-			      <property name="right_padding">0</property>
+		<child internal-child="vbox">
+			<widget class="GtkVBox" id="dialog-vbox1">
+				<property name="visible">True</property>
+				<property name="homogeneous">False</property>
+				<property name="spacing">0</property>
 
-			      <child>
-				<widget class="GtkHBox" id="hbox32">
-				  <property name="visible">True</property>
-				  <property name="homogeneous">False</property>
-				  <property name="spacing">2</property>
+				<child internal-child="action_area">
+					<widget class="GtkHButtonBox" id="dialog-action_area1">
+						<property name="visible">True</property>
+						<property name="layout_style">GTK_BUTTONBOX_END</property>
 
-				  <child>
-				    <widget class="GtkImage" id="image19">
-				      <property name="visible">True</property>
-				      <property name="stock">gtk-go-forward</property>
-				      <property name="icon_size">4</property>
-				      <property name="xalign">0.5</property>
-				      <property name="yalign">0.5</property>
-				      <property name="xpad">0</property>
-				      <property name="ypad">0</property>
-				    </widget>
-				    <packing>
-				      <property name="padding">0</property>
-				      <property name="expand">False</property>
-				      <property name="fill">False</property>
-				    </packing>
-				  </child>
+						<child>
+							<placeholder/>
+						</child>
+					</widget>
+					<packing>
+						<property name="padding">0</property>
+						<property name="expand">True</property>
+						<property name="fill">True</property>
+						<property name="pack_type">GTK_PACK_END</property>
+					</packing>
+				</child>
 
-				  <child>
-				    <widget class="GtkLabel" id="label78">
-				      <property name="visible">True</property>
-				      <property name="label" translatable="yes">Symlink</property>
-				      <property name="use_underline">True</property>
-				      <property name="use_markup">False</property>
-				      <property name="justify">GTK_JUSTIFY_LEFT</property>
-				      <property name="wrap">False</property>
-				      <property name="selectable">False</property>
-				      <property name="xalign">0.5</property>
-				      <property name="yalign">0.5</property>
-				      <property name="xpad">0</property>
-				      <property name="ypad">0</property>
-				      <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-				      <property name="width_chars">-1</property>
-				      <property name="single_line_mode">False</property>
-				      <property name="angle">0</property>
-				    </widget>
-				    <packing>
-				      <property name="padding">0</property>
-				      <property name="expand">False</property>
-				      <property name="fill">False</property>
-				    </packing>
-				  </child>
-				</widget>
-			      </child>
-			    </widget>
-			  </child>
+				<child>
+					<widget class="GtkHBox" id="hbox23">
+						<property name="visible">True</property>
+						<property name="homogeneous">False</property>
+						<property name="spacing">0</property>
+
+						<child>
+							<widget class="GtkLabel" id="lblmsg">
+								<property name="visible">True</property>
+								<property name="label" translatable="yes"></property>
+								<property name="use_underline">False</property>
+								<property name="use_markup">False</property>
+								<property name="justify">GTK_JUSTIFY_CENTER</property>
+								<property name="wrap">False</property>
+								<property name="selectable">False</property>
+								<property name="xalign">0.5</property>
+								<property name="yalign">0.5</property>
+								<property name="xpad">3</property>
+								<property name="ypad">0</property>
+								<property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+								<property name="width_chars">-1</property>
+								<property name="single_line_mode">False</property>
+								<property name="angle">0</property>
+							</widget>
+							<packing>
+								<property name="padding">0</property>
+								<property name="expand">False</property>
+								<property name="fill">False</property>
+							</packing>
+						</child>
+
+						<child>
+							<widget class="GtkEntry" id="entry">
+								<property name="visible">True</property>
+								<property name="can_focus">True</property>
+								<property name="editable">True</property>
+								<property name="visibility">True</property>
+								<property name="max_length">0</property>
+								<property name="text" translatable="yes"></property>
+								<property name="has_frame">True</property>
+								<property name="invisible_char">*</property>
+								<property name="activates_default">True</property>
+							</widget>
+							<packing>
+								<property name="padding">0</property>
+								<property name="expand">True</property>
+								<property name="fill">True</property>
+								<property name="pack_type">GTK_PACK_END</property>
+							</packing>
+						</child>
+					</widget>
+					<packing>
+						<property name="padding">3</property>
+						<property name="expand">True</property>
+						<property name="fill">True</property>
+					</packing>
+				</child>
+
+				<child>
+					<widget class="GtkAlignment" id="alignment13">
+						<property name="visible">True</property>
+						<property name="xalign">1</property>
+						<property name="yalign">0.5</property>
+						<property name="xscale">0</property>
+						<property name="yscale">1</property>
+						<property name="top_padding">0</property>
+						<property name="bottom_padding">0</property>
+						<property name="left_padding">0</property>
+						<property name="right_padding">6</property>
+
+						<child>
+							<widget class="GtkCheckButton" id="chkAgain">
+								<property name="label" translatable="yes">ask me this in future?</property>
+								<property name="use_underline">True</property>
+								<property name="relief">GTK_RELIEF_NORMAL</property>
+								<property name="focus_on_click">False</property>
+								<property name="active">True</property>
+								<property name="inconsistent">False</property>
+								<property name="draw_indicator">True</property>
+							</widget>
+						</child>
+					</widget>
+					<packing>
+						<property name="padding">2</property>
+						<property name="expand">False</property>
+						<property name="fill">False</property>
+						<property name="pack_type">GTK_PACK_END</property>
+					</packing>
+				</child>
 			</widget>
-		      </child>
-		    </widget>
-		    <packing>
-		      <property name="padding">0</property>
-		      <property name="expand">False</property>
-		      <property name="fill">False</property>
-		    </packing>
-		  </child>
-		</widget>
-		<packing>
-		  <property name="padding">0</property>
-		  <property name="expand">False</property>
-		  <property name="fill">False</property>
-		</packing>
-	      </child>
-
-	      <child>
-		<widget class="GtkScrolledWindow" id="scrolledwindow13">
-		  <property name="visible">True</property>
-		  <property name="can_focus">True</property>
-		  <property name="hscrollbar_policy">GTK_POLICY_NEVER</property>
-		  <property name="vscrollbar_policy">GTK_POLICY_NEVER</property>
-		  <property name="shadow_type">GTK_SHADOW_IN</property>
-		  <property name="window_placement">GTK_CORNER_TOP_LEFT</property>
-
-		  <child>
-		    <widget class="GtkViewport" id="viewport1">
-		      <property name="visible">True</property>
-		      <property name="shadow_type">GTK_SHADOW_NONE</property>
-
-		      <child>
-			<widget class="GtkEntry" id="status">
-			  <property name="visible">True</property>
-			  <property name="can_focus">True</property>
-			  <property name="editable">False</property>
-			  <property name="visibility">True</property>
-			  <property name="max_length">0</property>
-			  <property name="text"></property>
-			  <property name="has_frame">False</property>
-			  <property name="invisible_char">*</property>
-			  <property name="activates_default">False</property>
-			</widget>
-		      </child>
-		    </widget>
-		  </child>
-		</widget>
-		<packing>
-		  <property name="padding">3</property>
-		  <property name="expand">False</property>
-		  <property name="fill">False</property>
-		</packing>
-	      </child>
-	    </widget>
-	    <packing>
-	      <property name="shrink">True</property>
-	      <property name="resize">True</property>
-	    </packing>
-	  </child>
-
-	  <child>
-	    <widget class="GtkScrolledWindow" id="scrolledwindow14">
-	      <property name="visible">True</property>
-	      <property name="can_focus">True</property>
-	      <property name="hscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-	      <property name="vscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-	      <property name="shadow_type">GTK_SHADOW_IN</property>
-	      <property name="window_placement">GTK_CORNER_TOP_LEFT</property>
-
-	      <child>
-		<widget class="GtkTextView" id="errors">
-		  <property name="visible">True</property>
-		  <property name="can_focus">True</property>
-		  <property name="editable">False</property>
-		  <property name="overwrite">False</property>
-		  <property name="accepts_tab">True</property>
-		  <property name="justification">GTK_JUSTIFY_LEFT</property>
-		  <property name="wrap_mode">GTK_WRAP_NONE</property>
-		  <property name="cursor_visible">True</property>
-		  <property name="pixels_above_lines">0</property>
-		  <property name="pixels_below_lines">0</property>
-		  <property name="pixels_inside_wrap">0</property>
-		  <property name="left_margin">0</property>
-		  <property name="right_margin">0</property>
-		  <property name="indent">0</property>
-		  <property name="text" translatable="yes"></property>
-		</widget>
-	      </child>
-	    </widget>
-	    <packing>
-	      <property name="shrink">True</property>
-	      <property name="resize">True</property>
-	    </packing>
-	  </child>
+		</child>
 	</widget>
-	<packing>
-	  <property name="padding">3</property>
-	  <property name="expand">True</property>
-	  <property name="fill">True</property>
-	</packing>
-      </child>
-    </widget>
-  </child>
-</widget>
-
-<widget class="GtkFileChooserDialog" id="PathChoose">
-  <property name="border_width">5</property>
-  <property name="action">GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER</property>
-  <property name="local_only">True</property>
-  <property name="select_multiple">False</property>
-  <property name="show_hidden">False</property>
-  <property name="do_overwrite_confirmation">False</property>
-  <property name="title" translatable="yes">Select Path</property>
-  <property name="type">GTK_WINDOW_TOPLEVEL</property>
-  <property name="window_position">GTK_WIN_POS_NONE</property>
-  <property name="modal">True</property>
-  <property name="resizable">True</property>
-  <property name="destroy_with_parent">False</property>
-  <property name="role">GtkFileChooserDialog</property>
-  <property name="decorated">True</property>
-  <property name="skip_taskbar_hint">False</property>
-  <property name="skip_pager_hint">False</property>
-  <property name="type_hint">GDK_WINDOW_TYPE_HINT_DIALOG</property>
-  <property name="gravity">GDK_GRAVITY_NORTH_WEST</property>
-  <property name="focus_on_map">True</property>
-  <property name="urgency_hint">False</property>
-  <signal name="delete_event" handler="quit" last_modification_time="Mon, 22 Jun 2009 18:33:11 GMT"/>
-
-  <child internal-child="vbox">
-    <widget class="GtkVBox" id="dialog-vbox2">
-      <property name="visible">True</property>
-      <property name="homogeneous">False</property>
-      <property name="spacing">2</property>
-
-      <child internal-child="action_area">
-	<widget class="GtkHButtonBox" id="dialog-action_area2">
-	  <property name="visible">True</property>
-	  <property name="layout_style">GTK_BUTTONBOX_END</property>
-
-	  <child>
-	    <widget class="GtkButton" id="cancel_path">
-	      <property name="visible">True</property>
-	      <property name="can_default">True</property>
-	      <property name="can_focus">True</property>
-	      <property name="label">gtk-cancel</property>
-	      <property name="use_stock">True</property>
-	      <property name="relief">GTK_RELIEF_NORMAL</property>
-	      <property name="focus_on_click">True</property>
-	      <property name="response_id">0</property>
-	      <signal name="clicked" handler="quit" last_modification_time="Mon, 22 Jun 2009 18:30:54 GMT"/>
-	    </widget>
-	  </child>
-
-	  <child>
-	    <widget class="GtkButton" id="ok_path">
-	      <property name="visible">True</property>
-	      <property name="can_default">True</property>
-	      <property name="has_default">True</property>
-	      <property name="can_focus">True</property>
-	      <property name="label">gtk-ok</property>
-	      <property name="use_stock">True</property>
-	      <property name="relief">GTK_RELIEF_NORMAL</property>
-	      <property name="focus_on_click">True</property>
-	      <property name="response_id">0</property>
-	      <signal name="clicked" handler="on_ok_clicked" last_modification_time="Tue, 23 Jun 2009 01:04:14 GMT"/>
-	    </widget>
-	  </child>
-	</widget>
-	<packing>
-	  <property name="padding">0</property>
-	  <property name="expand">False</property>
-	  <property name="fill">True</property>
-	  <property name="pack_type">GTK_PACK_END</property>
-	</packing>
-      </child>
-    </widget>
-  </child>
-</widget>
-
-<widget class="GtkDialog" id="UserInteraction">
-  <property name="title" translatable="yes"></property>
-  <property name="type">GTK_WINDOW_TOPLEVEL</property>
-  <property name="window_position">GTK_WIN_POS_CENTER_ON_PARENT</property>
-  <property name="modal">True</property>
-  <property name="default_width">150</property>
-  <property name="default_height">100</property>
-  <property name="resizable">True</property>
-  <property name="destroy_with_parent">False</property>
-  <property name="decorated">True</property>
-  <property name="skip_taskbar_hint">False</property>
-  <property name="skip_pager_hint">False</property>
-  <property name="type_hint">GDK_WINDOW_TYPE_HINT_DIALOG</property>
-  <property name="gravity">GDK_GRAVITY_NORTH_WEST</property>
-  <property name="focus_on_map">True</property>
-  <property name="urgency_hint">False</property>
-  <property name="has_separator">True</property>
-  <signal name="destroy" handler="quit"/>
-
-  <child internal-child="vbox">
-    <widget class="GtkVBox" id="dialog-vbox1">
-      <property name="visible">True</property>
-      <property name="homogeneous">False</property>
-      <property name="spacing">0</property>
-
-      <child internal-child="action_area">
-	<widget class="GtkHButtonBox" id="dialog-action_area1">
-	  <property name="visible">True</property>
-	  <property name="layout_style">GTK_BUTTONBOX_END</property>
-
-	  <child>
-	    <placeholder/>
-	  </child>
-	</widget>
-	<packing>
-	  <property name="padding">0</property>
-	  <property name="expand">True</property>
-	  <property name="fill">True</property>
-	  <property name="pack_type">GTK_PACK_END</property>
-	</packing>
-      </child>
-
-      <child>
-	<widget class="GtkHBox" id="hbox23">
-	  <property name="visible">True</property>
-	  <property name="homogeneous">False</property>
-	  <property name="spacing">0</property>
-
-	  <child>
-	    <widget class="GtkLabel" id="lblmsg">
-	      <property name="visible">True</property>
-	      <property name="label" translatable="yes"></property>
-	      <property name="use_underline">False</property>
-	      <property name="use_markup">False</property>
-	      <property name="justify">GTK_JUSTIFY_CENTER</property>
-	      <property name="wrap">False</property>
-	      <property name="selectable">False</property>
-	      <property name="xalign">0.5</property>
-	      <property name="yalign">0.5</property>
-	      <property name="xpad">3</property>
-	      <property name="ypad">0</property>
-	      <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-	      <property name="width_chars">-1</property>
-	      <property name="single_line_mode">False</property>
-	      <property name="angle">0</property>
-	    </widget>
-	    <packing>
-	      <property name="padding">0</property>
-	      <property name="expand">False</property>
-	      <property name="fill">False</property>
-	    </packing>
-	  </child>
-
-	  <child>
-	    <widget class="GtkEntry" id="entry">
-	      <property name="visible">True</property>
-	      <property name="can_focus">True</property>
-	      <property name="editable">True</property>
-	      <property name="visibility">True</property>
-	      <property name="max_length">0</property>
-	      <property name="text" translatable="yes"></property>
-	      <property name="has_frame">True</property>
-	      <property name="invisible_char">*</property>
-	      <property name="activates_default">True</property>
-	    </widget>
-	    <packing>
-	      <property name="padding">0</property>
-	      <property name="expand">True</property>
-	      <property name="fill">True</property>
-	      <property name="pack_type">GTK_PACK_END</property>
-	    </packing>
-	  </child>
-	</widget>
-	<packing>
-	  <property name="padding">3</property>
-	  <property name="expand">True</property>
-	  <property name="fill">True</property>
-	</packing>
-      </child>
-
-      <child>
-	<widget class="GtkAlignment" id="alignment13">
-	  <property name="visible">True</property>
-	  <property name="xalign">1</property>
-	  <property name="yalign">0.5</property>
-	  <property name="xscale">0</property>
-	  <property name="yscale">1</property>
-	  <property name="top_padding">0</property>
-	  <property name="bottom_padding">0</property>
-	  <property name="left_padding">0</property>
-	  <property name="right_padding">6</property>
-
-	  <child>
-	    <widget class="GtkCheckButton" id="chkAgain">
-	      <property name="label" translatable="yes">ask me this in future?</property>
-	      <property name="use_underline">True</property>
-	      <property name="relief">GTK_RELIEF_NORMAL</property>
-	      <property name="focus_on_click">False</property>
-	      <property name="active">True</property>
-	      <property name="inconsistent">False</property>
-	      <property name="draw_indicator">True</property>
-	    </widget>
-	  </child>
-	</widget>
-	<packing>
-	  <property name="padding">2</property>
-	  <property name="expand">False</property>
-	  <property name="fill">False</property>
-	  <property name="pack_type">GTK_PACK_END</property>
-	</packing>
-      </child>
-    </widget>
-  </child>
-</widget>
 
 </glade-interface>


### PR DESCRIPTION
Enable to add multiple folders to search and to exclude
- Edited `fslint-gui.on_addOkDir_clicked()`
- Edited `fslint-gui.on_addBadDir_clicked()`
- Edited `fslint.grade`line 3922: set `select_multiple` to `true`
- Extracted a constant for *bad dirs*

I hope that you find these improvements useful.